### PR TITLE
Rack expectations test

### DIFF
--- a/spec/grape/rack_expectations_spec.rb
+++ b/spec/grape/rack_expectations_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'Rack expectations' do
+
+  it 'demonstrates the Tempfile bug' do
+    input = Tempfile.new 'rubbish'
+    begin
+      app = Class.new(Grape::API) do
+        format :json
+        post do
+          { params_keys: params.keys }
+        end
+      end
+      input.write({ test: "123" * 10_000 }.to_json)
+      input.rewind
+      options = {
+        input: input,
+        method: 'POST',
+        'CONTENT_TYPE' => 'application/json'
+      }
+      env = Rack::MockRequest.env_for("/", options)
+      JSON.parse(app.call(env)[2].body.first)['params_keys'].should =~ ['route_info', 'test']
+    ensure
+      input.unlink
+    end
+  end
+end


### PR DESCRIPTION
Per the description #559, this test demonstrates a bug in `rack 1.5.2` whereby `params` is not correctly populated when `rack.input` is a `Tempfile`

`rack.input` is a `Tempfile` in various circumstances. In our case it was with a [`puma`](https://github.com/puma/puma) webserver frontend serving [requests with a large body](https://github.com/puma/puma/blob/master/lib/puma/server.rb#L667-L669)

This test is designed to fail against `rack 1.5.2` - but works against `rack#master` ([`8dc31fec37` at the time of writing](https://github.com/rack/rack/commit/8dc31fec37f6f53a5f0f8e24274da9035abd92b2))