### PR TITLE
Wierd behavior with optional array

### DIFF
--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -514,7 +514,7 @@ describe Grape::Endpoint do
     end
 
     describe "hash array with default value" do
-      it do
+      it "is nil when value is not provided" do
         subject.params do
           optional :my_simple_value, type: String
           optional :my_array, type: Array do
@@ -522,11 +522,15 @@ describe Grape::Endpoint do
           end
         end
         subject.post("/array") do
-          params[:my_simple_value].should == nil
-          params[:my_array].should == nil
+          {
+            my_array: params[:my_array].nil?,
+            my_simple_value: params[:my_simple_value].nil?
+          }.to_json
         end
 
         post "/array"
+
+        expect(JSON.parse(last_response.body)).to eq(my_array: true, my_simple_value: true)
       end
     end
   end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -513,6 +513,22 @@ describe Grape::Endpoint do
       end
     end
 
+    describe "hash array with default value" do
+      it do
+        subject.params do
+          optional :my_simple_value, type: String
+          optional :my_array, type: Array do
+            requires :foo, default: "bar"
+          end
+        end
+        subject.post("/array") do
+          params[:my_simple_value].should == nil
+          params[:my_array].should == nil
+        end
+
+        post "/array"
+      end
+    end
   end
 
   describe '#error!' do


### PR DESCRIPTION
Hi. First of all, thanks for a great framework.

I think I have found a bug:

If I have an optional array of hashes and one of the hash values has a default, the resulting param is weird when not provided.

Example:

    params do
      optional :some_array, type: Array do
        optional :foo, default: "bar"
      end
    end

When not providing `:some_array`, I would expect `params[:some_array]` to be `nil`, but it is `{foo: "bar"}` (which is not even an array).

In this pull request I have med a spec that shows this.

Are my expectations right?