### PR TITLE
Version specs

### DIFF
--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -35,10 +35,13 @@ module Grape
             fail Grape::Exceptions::MissingVendorOption.new if options[:using] == :header && !options.key?(:vendor)
 
             @versions = versions | args
-            nest(block) do
-              namespace_inheritable(:version, args)
-              namespace_inheritable(:version_options, options)
-            end
+
+            namespace_inheritable(:version, args)
+            namespace_inheritable(:version_options, options)
+
+            instance_eval(&block) if block_given?
+
+            # reset_validations!
           end
 
           @versions.last unless @versions.nil?

--- a/spec/grape/dsl/routing_spec.rb
+++ b/spec/grape/dsl/routing_spec.rb
@@ -14,8 +14,13 @@ module Grape
       let(:options) { { a: :b } }
       let(:path) { '/dummy' }
 
-      xdescribe '.version' do
-        it 'does some thing'
+      describe '.version' do
+        it 'sets a version for route' do
+          version = 'v1'
+          expect(subject).to receive(:namespace_inheritable).with(:version, [version])
+          expect(subject).to receive(:namespace_inheritable).with(:version_options, using: :path)
+          expect(subject.version(version)).to eq(version)
+        end
       end
 
       describe '.prefix' do
@@ -140,8 +145,12 @@ module Grape
         it 'does some thing'
       end
 
-      xdescribe '.versions' do
-        it 'does some thing'
+      describe '.versions' do
+        it 'returns last defined version' do
+          subject.version 'v1'
+          subject.version 'v2'
+          expect(subject.version).to eq('v2')
+        end
       end
     end
   end


### PR DESCRIPTION
Hi, I've started to implement routing specs and have some questions.

Routing module is using "nest" method from API class, I think this coupling between is not quite necessary. I get rid of this class, the only thing what it is doing is calling provided block (name_inheritable methods) then making instance_eval of passed block as parameter - so I did the same. 
However, side effect of "nest" method is reset_validations! method (from Grape::DSL::Validations module) and I'm not if I should mimic it's behaviour too. 

Second thing, method "versions" suggest that we could expect probably an array of versions, but it keeps just latest defined version. Maybe we should change it in some way?