### PR TITLE
Check supported format even when there is no Content-Type given

### DIFF
--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -48,7 +48,6 @@ module Grape
       # store read input in env['api.request.input']
       def read_body_input
         if (request.post? || request.put? || request.patch? || request.delete?) &&
-           (!request.form_data? || !request.media_type) &&
            (!request.parseable_data?) &&
            (request.content_length.to_i > 0 || request.env['HTTP_TRANSFER_ENCODING'] == 'chunked')
 

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -582,6 +582,17 @@ describe Grape::Endpoint do
       expect(last_response.body).to eq('{"error":"The requested content-type \'application/xml\' is not supported."}')
     end
 
+    it 'responds with a 406 for when no content-type provided' do
+      subject.format :json
+
+      subject.put '/request_body' do
+        params[:user]
+      end
+      put '/request_body', '<user>Bobby T.</user>'
+      expect(last_response.status).to eq(406)
+      expect(last_response.body).to eq('{"error":"The requested content-type \'application/x-www-form-urlencoded\' is not supported."}')
+    end
+
     context 'content type with params' do
       before do
         subject.format :json
@@ -604,7 +615,7 @@ describe Grape::Endpoint do
 
     context 'precedence' do
       before do
-        subject.format :json
+        subject.default_format :json
         subject.namespace '/:id' do
           get do
             {


### PR DESCRIPTION
I found this "thing" investigating #726 .

I'm not sure why there is a check with

``
!request.form_data? || !request.media_type
``
But removing it does not break test suite (one change in the very bottom of this commit) and gives us desired feature I guess