### PR TITLE
Allows values to be a kind of the coerced type in range

### DIFF
--- a/lib/grape/validations/validators/values.rb
+++ b/lib/grape/validations/validators/values.rb
@@ -10,6 +10,7 @@ module Grape
         return unless params[attr_name] || required_for_root_scope?
 
         values = @values.is_a?(Proc) ? @values.call : @values
+        values = values.to_a if values.is_a? Range
         param_array = params[attr_name].nil? ? [nil] : Array.wrap(params[attr_name])
         unless (param_array - values).empty?
           fail Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message_key: :values

--- a/spec/grape/validations/validators/values_spec.rb
+++ b/spec/grape/validations/validators/values_spec.rb
@@ -64,6 +64,13 @@ describe Grape::Validations::ValuesValidator do
         end
 
         params do
+          requires :type, type: Integer, desc: 'An integer', values: 10..11, default: 10
+        end
+        get '/range' do
+          { type: params[:type] }
+        end
+
+        params do
           requires :type, type: Array[Integer], desc: 'An integer', values: [10, 11], default: 10
         end
         get '/values/array_coercion' do
@@ -176,6 +183,12 @@ describe Grape::Validations::ValuesValidator do
 
   it 'allows values to be a kind of the coerced type not just an instance of it' do
     get('/values/coercion', type: 10)
+    expect(last_response.status).to eq 200
+    expect(last_response.body).to eq({ type: 10 }.to_json)
+  end
+
+  it 'allows values to be a kind of the coerced type not just an instance of it' do
+    get('/range', type: 10)
     expect(last_response.status).to eq 200
     expect(last_response.body).to eq({ type: 10 }.to_json)
   end


### PR DESCRIPTION
My code like this ```requires :month, type: Integer, values: 1..12``, the Range values coercion is workable.Before it workable, now it failed.

https://github.com/u2/grape/commit/0df3bda5d288d03d1647170ab2cbcb645001a324#diff-45b62b4ed0aed7ceff346c347f76570e

After ```!(@values.is_a?(Proc) ? @values.call : @values).include?(params[attr_name])``` chang to ```(param_array - values).empty?```, the Range values coercion raise a error ```no implicit conversion of Range into Array```

 