### PR TITLE
Updating README.md section of 'Stubbing Helpers' to use up to date RSpec...

### DIFF
--- a/README.md
+++ b/README.md
@@ -2333,7 +2333,7 @@ request.
 describe 'an endpoint that needs helpers stubbed' do
   before do
     Grape::Endpoint.before_each do |endpoint|
-      endpoint.stub(:helper_name).and_return('desired_value')
+      allow(endpoint).to receive(:helper_name).and_return('desired_value')
     end
   end
 


### PR DESCRIPTION
The Read Me for this was using the old RSpec .stub method, which was a little confusing, I think we should have the latest approach (allow... to... receive) in the documentation. 