### PR TITLE
add support for scoped callbcaks within a version block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Next Release
 * [#876](https://github.com/intridea/grape/pull/876): Call to `declared(params)` now returns a `Hashie::Mash` - [@rodzyn](https://github.com/rodzyn).
 * [#879](https://github.com/intridea/grape/pull/879): The `route_info` value is no longer included in `params` Hash - [@rodzyn](https://github.com/rodzyn).
 * [#881](https://github.com/intridea/grape/issues/881): Fixed `Grape::Validations::ValuesValidator` support for `Range` type - [@ajvondrak](https://github.com/ajvondrak).
+* [#901](https://github.com/intridea/grape/pull/901): Fix: callbacks defined in a version block are only called for the routes defined in that block - [@kushkella](https://github.com/kushkella).
 * Your contribution here.
 
 0.10.1 (12/28/2014)

--- a/README.md
+++ b/README.md
@@ -2162,6 +2162,39 @@ GET /123        # 'Fixnum'
 GET /foo        # 400 error - 'blah is invalid'
 ```
 
+When a callback is defined within a version block, it's only called for the routes defined in that block.
+
+```ruby
+class Test < Grape::API
+  resource :foo do
+    version 'v1', :using => :path do
+      before do
+        @output ||= 'v1-'
+      end
+      get '/' do
+        @output += 'hello'
+      end
+    end
+
+    version 'v2', :using => :path do
+      before do
+        @output ||= 'v2-'
+      end
+      get '/' do
+        @output += 'hello'
+      end
+    end
+  end
+end
+```
+
+The behaviour is then:
+
+```bash
+GET /foo/v1       # 'v1-hello'
+GET /foo/v2       # 'v2-hello'
+```
+
 ## Anchoring
 
 Grape by default anchors all request paths, which means that the request URL
@@ -2270,13 +2303,13 @@ class Twitter::APITest < MiniTest::Unit::TestCase
   def app
     Twitter::API
   end
-  
+
   def test_get_api_statuses_public_timeline_returns_an_empty_array_of_statuses
     get "/api/statuses/public_timeline"
     assert last_response.ok?
     assert_equal JSON.parse(last_response.body), []
   end
-  
+
   def test_get_api_statuses_id_returns_a_status_by_id
     status = Status.create!
     get "/api/statuses/#{status.id}"
@@ -2326,13 +2359,13 @@ class Twitter::APITest < ActiveSupport::TestCase
   def app
     Rails.application
   end
-  
+
   test "GET /api/statuses/public_timeline returns an empty array of statuses" do
     get "/api/statuses/public_timeline"
     assert last_response.ok?
     assert_equal JSON.parse(last_response.body), []
   end
-  
+
   test "GET /api/statuses/:id returns a status by id" do
     status = Status.create!
     get "/api/statuses/#{status.id}"

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -19,6 +19,13 @@ Key route_info is excluded from params.
 
 See [#879](https://github.com/intridea/grape/pull/879) for more information.
 
+
+#### Fix callbacks within a version block
+
+Callbacks defined in a version block are only called for the routes defined in that block. This was a regression introduced in Grape 0.10.0, and is fixed in this version.
+
+See [#901](https://github.com/intridea/grape/pull/901) for more information.
+
 ### Upgrading to >= 0.10.1
 
 #### Changes to `declared(params, include_missing: false)`

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -36,10 +36,17 @@ module Grape
 
             @versions = versions | args
 
-            namespace_inheritable(:version, args)
-            namespace_inheritable(:version_options, options)
+            if block_given?
+              within_namespace do
+                namespace_inheritable(:version, args)
+                namespace_inheritable(:version_options, options)
 
-            instance_eval(&block) if block_given?
+                instance_eval(&block)
+              end
+            else
+              namespace_inheritable(:version, args)
+              namespace_inheritable(:version_options, options)
+            end
 
             # reset_validations!
           end

--- a/spec/shared/versioning_examples.rb
+++ b/spec/shared/versioning_examples.rb
@@ -107,6 +107,38 @@ shared_examples_for 'versioning' do
     end
   end
 
+  context 'with before block defined within a version block' do
+    it 'calls before block that is defined within the version block' do
+      subject.format :txt
+      subject.prefix 'api'
+      subject.version 'v2', macro_options do
+        before do
+          @output ||= 'v2-'
+        end
+        get 'version' do
+          @output += 'version'
+        end
+      end
+
+      subject.version 'v1', macro_options do
+        before do
+          @output ||= 'v1-'
+        end
+        get 'version' do
+          @output += 'version'
+        end
+      end
+
+      versioned_get '/version', 'v1', macro_options.merge(prefix: subject.prefix)
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq('v1-version')
+
+      versioned_get '/version', 'v2', macro_options.merge(prefix: subject.prefix)
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq('v2-version')
+    end
+  end
+
   it 'does not overwrite version parameter with API version' do
     subject.format :txt
     subject.version 'v1', macro_options


### PR DESCRIPTION
Please refer https://github.com/intridea/grape/issues/898. I haven't really understood in depth how Grape works internally, but I think this should solve the problem. I would really appreciate if you could give some feedback. 

I haven't documented this PR since I'm not sure if this is the correct fix. After I receive some feedback, I'll document this PR. Thanks!