### PR TITLE
Add the ability to default a path version

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,30 @@ Using this versioning strategy, clients should pass the desired version in the U
 
     curl -H http://localhost:9292/v1/statuses/public_timeline
 
+You may optionally specify the `:default` option for a path version, which will make the version in the URL optional. For example, the following API will respond to either the URL `/v1/foo` or just `/foo`. In either case, the value of `env['api.version']` will be `'v1'`.
+
+```ruby
+class API < Grape::API
+  version 'v1', using: :path, default: 'v1'
+
+  get :foo do
+    # ...
+  end
+end
+```
+
+This is also useful for "evolving" your APIs (see [this blog post](http://code.dblock.org/2013/07/19/evolving-apis-using-grape-api-versioning.html)). For example, the following API responds to `/v1/foo` or `/v2/foo`, but `/foo` will behave like `/v2/foo`:
+
+```ruby
+class API < Grape::API
+  version 'v1', 'v2', default: 'v2'
+
+  get :foo do
+    # ...
+  end
+end
+```
+
 ### Header
 
 ```ruby

--- a/lib/grape/middleware/versioner/path.rb
+++ b/lib/grape/middleware/versioner/path.rb
@@ -31,13 +31,13 @@ module Grape
             path = Rack::Mount::Utils.normalize_path(path)
           end
 
+          env['api.version'] = default_version if default_version
+
           pieces = path.split('/')
           potential_version = pieces[1]
           if potential_version =~ options[:pattern]
             if unrecognized_version?(potential_version)
-              if default_version
-                env['api.version'] = default_version
-              else
+              unless default_version
                 throw :error, status: 404, message: '404 API Version Not Found'
               end
             else

--- a/lib/grape/middleware/versioner/path.rb
+++ b/lib/grape/middleware/versioner/path.rb
@@ -34,10 +34,15 @@ module Grape
           pieces = path.split('/')
           potential_version = pieces[1]
           if potential_version =~ options[:pattern]
-            if options[:versions] && !options[:versions].find { |v| v.to_s == potential_version }
-              throw :error, status: 404, message: '404 API Version Not Found'
+            if unrecognized_version?(potential_version)
+              if default_version
+                env['api.version'] = default_version
+              else
+                throw :error, status: 404, message: '404 API Version Not Found'
+              end
+            else
+              env['api.version'] = potential_version
             end
-            env['api.version'] = potential_version
           end
         end
 
@@ -45,6 +50,16 @@ module Grape
 
         def prefix
           Rack::Mount::Utils.normalize_path(options[:prefix].to_s) if options[:prefix]
+        end
+
+        def default_version
+          options[:version_options] && options[:version_options][:default]
+        end
+
+        def unrecognized_version?(potential_version)
+          options[:versions] && !options[:versions].find do |v|
+            v.to_s == potential_version
+          end
         end
       end
     end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -85,7 +85,7 @@ describe Grape::API do
         let(:macro_options) do
           {
             using: :path,
-            default: 'default_version',
+            default: 'default_version'
           }
         end
       end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -95,10 +95,10 @@ describe Grape::API do
       it 'sets the API version to the default' do
         subject.format :txt
         subject.version 'v1', using: :path, default: 'default_version'
-        subject.get :hello do
+        subject.get do
           "Version: #{env['api.version']}"
         end
-        get '/hello'
+        get '/'
         expect(last_response.body).to eql 'Version: default_version'
       end
 

--- a/spec/grape/path_spec.rb
+++ b/spec/grape/path_spec.rb
@@ -70,6 +70,17 @@ module Grape
         expect(path.uses_path_versioning?).to be false
       end
 
+      it 'is false when the version option is header with a default' do
+        path = Path.new(
+          anything,
+          anything,
+          version: 'v1',
+          version_options: { using: :header, default: 'v2' }
+        )
+
+        expect(path.uses_path_versioning?).to be false
+      end
+
       it 'is true when the version option is path' do
         path = Path.new(
           anything,
@@ -79,6 +90,68 @@ module Grape
         )
 
         expect(path.uses_path_versioning?).to be true
+      end
+
+      it 'is true when the version option is path with a default' do
+        path = Path.new(
+          anything,
+          anything,
+          version: 'v1',
+          version_options: { using: :path, default: 'v2' }
+        )
+
+        expect(path.uses_path_versioning?).to be true
+      end
+    end
+
+    describe '#optional_path_versioning?' do
+      it 'is false when the version setting is nil' do
+        path = Path.new(anything, anything, version: nil)
+        expect(path.optional_path_versioning?).to be false
+      end
+
+      it 'is false when the version option is header' do
+        path = Path.new(
+          anything,
+          anything,
+          version: 'v1',
+          version_options: { using: :header }
+        )
+
+        expect(path.optional_path_versioning?).to be false
+      end
+
+      it 'is false when the version option is header with a default' do
+        path = Path.new(
+          anything,
+          anything,
+          version: 'v1',
+          version_options: { using: :header, default: 'v2' }
+        )
+
+        expect(path.optional_path_versioning?).to be false
+      end
+
+      it 'is false when the version option is path without a default' do
+        path = Path.new(
+          anything,
+          anything,
+          version: 'v1',
+          version_options: { using: :path }
+        )
+
+        expect(path.optional_path_versioning?).to be false
+      end
+
+      it 'is true when the version option is path with a default' do
+        path = Path.new(
+          anything,
+          anything,
+          version: 'v1',
+          version_options: { using: :path, default: 'v2' }
+        )
+
+        expect(path.optional_path_versioning?).to be true
       end
     end
 
@@ -154,6 +227,67 @@ module Grape
           )
 
           expect(path.path).to eql('/foo/hello')
+        end
+      end
+
+      context ':version' do
+        it 'is included when given the path version option' do
+          path = Path.new(
+            'raw_path',
+            'namespace',
+            version: 'v1',
+            version_options: { using: :path }
+          )
+
+          expect(path.path).to eql('/:version/namespace/raw_path')
+        end
+
+        it 'is excluded when given the header version option' do
+          path = Path.new(
+            'raw_path',
+            'namespace',
+            version: 'v1',
+            version_options: { using: :header }
+          )
+
+          expect(path.path).to eql('/namespace/raw_path')
+        end
+
+        context 'with a default version' do
+          it 'is made optional at the beginning of the path' do
+            path = Path.new(
+              'raw_path',
+              'namespace',
+              version: 'v1|v2',
+              version_options: { using: :path, default: 'v2' }
+            )
+
+            expect(path.path).to eql('/(:version/)namespace/raw_path')
+          end
+
+          it 'is made optional in the middle of the path' do
+            path = Path.new(
+              'raw_path',
+              'namespace',
+              mount_path: '/foo',
+              root_prefix: '/hello',
+              version: 'v1|v2',
+              version_options: { using: :path, default: 'v2' }
+            )
+
+            expect(path.path).to eql('/foo/hello(/:version)/namespace/raw_path')
+          end
+
+          it 'is made optional at the end of the path' do
+            path = Path.new(
+              nil,
+              nil,
+              version: 'v1|v2',
+              version_options: { using: :path, default: 'v2' }
+            )
+
+            expect(path.path).to eql('/(:version)')
+          end
         end
       end
 


### PR DESCRIPTION
In support of porting my legacy application, I needed a path-versioned API. Basically, I was doing something similar to [this blog post](http://code.dblock.org/2013/07/19/evolving-apis-using-grape-api-versioning.html).

Problem is, the legacy API also responded *without* a version in the path. So, we supported `/v1/foo` and `/v2/foo`, but *also* `/foo`, which behaved just like `/v2/foo`. I needed a way to "default" the version in a URL path, which is kind of tricky because it affects Route definitions. Instead of working around with something kludgey (e.g., looked into mounting the same "core logic" in multiple places, but [that has its own problems](https://github.com/intridea/grape/issues/570)), I poked around and figured out how to implement this feature.

Let me know how it looks, or if I'm barking up the wrong tree with a feature like this.

P.S.: Not sure what CHANGELOG entry to make until a pull request is set up so I can link it from the CHANGELOG. :)