### PR TITLE
Fixed issues related to invalid accept headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Next Release
 * [#901](https://github.com/intridea/grape/pull/901): Fix: callbacks defined in a version block are only called for the routes defined in that block - [@kushkella](https://github.com/kushkella).
 * [#886](https://github.com/intridea/grape/pull/886): Group of parameters made to require an explicit type of Hash or Array - [@jrichter1](https://github.com/jrichter1).
 * [#912](https://github.com/intridea/grape/pull/912): Extended the `:using` feature for param documentation to `optional` fields - [@croeck](https://github.com/croeck).
+* [#913](https://github.com/intridea/grape/pull/913): Fix: Invalid accept headers are not processed by rescue handlers - [@croeck](https://github.com/croeck).
+* [#913](https://github.com/intridea/grape/pull/913): Fix: Invalid accept headers cause internal processing errors (500) when http_codes are defined - [@croeck](https://github.com/croeck).
 * Your contribution here.
 
 0.10.1 (12/28/2014)

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -57,6 +57,7 @@ module Grape
     autoload :IncompatibleOptionValues,       'grape/exceptions/incompatible_option_values'
     autoload :MissingGroupTypeError,          'grape/exceptions/missing_group_type'
     autoload :UnsupportedGroupTypeError,      'grape/exceptions/unsupported_group_type'
+    autoload :InvalidAcceptHeader,            'grape/exceptions/invalid_accept_header'
   end
 
   module ErrorFormatter

--- a/lib/grape/error_formatter/base.rb
+++ b/lib/grape/error_formatter/base.rb
@@ -41,7 +41,7 @@ module Grape
           http_codes = env['rack.routing_args'][:route_info].route_http_codes || []
           found_code = http_codes.find do |http_code|
             (http_code[0].to_i == env['api.endpoint'].status) && http_code[2].respond_to?(:represent)
-          end
+          end if env['api.endpoint'].request
 
           presenter = found_code[2] if found_code
         end

--- a/lib/grape/exceptions/invalid_accept_header.rb
+++ b/lib/grape/exceptions/invalid_accept_header.rb
@@ -1,0 +1,10 @@
+# encoding: utf-8
+module Grape
+  module Exceptions
+    class InvalidAcceptHeader < Base
+      def initialize(message, headers)
+        super(message: compose_message('invalid_accept_header', message: message), status: 406, headers: headers)
+      end
+    end
+  end
+end

--- a/lib/grape/locale/en.yml
+++ b/lib/grape/locale/en.yml
@@ -35,4 +35,7 @@ en:
         all_or_none: 'provide all or none of parameters'
         missing_group_type: 'group type is required'
         unsupported_group_type: 'group type must be Array or Hash'
+        invalid_accept_header:
+          problem: 'Invalid accept header'
+          resolution: '%{message}'
 

--- a/spec/grape/exceptions/invalid_accept_header_spec.rb
+++ b/spec/grape/exceptions/invalid_accept_header_spec.rb
@@ -1,0 +1,330 @@
+require 'spec_helper'
+
+describe Grape::Exceptions::InvalidAcceptHeader do
+  shared_examples_for 'a valid request' do
+    it 'does return with status 200' do
+      expect(last_response.status).to eq 200
+    end
+    it 'does return the expected result' do
+      expect(last_response.body).to eq('beer received')
+    end
+  end
+  shared_examples_for 'a cascaded request' do
+    it 'does not find a matching route' do
+      expect(last_response.status).to eq 404
+    end
+  end
+  shared_examples_for 'a not-cascaded request' do
+    it 'does not include the X-Cascade=pass header' do
+      expect(last_response.headers['X-Cascade']).to be_nil
+    end
+    it 'does not accept the request' do
+      expect(last_response.status).to eq 406
+    end
+  end
+  shared_examples_for 'a rescued request' do
+    it 'does not include the X-Cascade=pass header' do
+      expect(last_response.headers['X-Cascade']).to be_nil
+    end
+    it 'does show rescue handler processing' do
+      expect(last_response.status).to eq 400
+      expect(last_response.body).to eq('message was processed')
+    end
+  end
+
+  context 'API with cascade=false and rescue_from :all handler' do
+    subject { Class.new(Grape::API) }
+    before {
+      subject.version 'v99', using: :header, vendor: 'vendorname', format: :json, cascade: false
+      subject.rescue_from :all do |e|
+        rack_response 'message was processed', 400, e[:headers]
+      end
+      subject.get '/beer' do
+        'beer received'
+      end
+    }
+
+    def app
+      subject
+    end
+
+    context 'that received a request with correct vendor and version' do
+      before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v99' }
+      it_should_behave_like 'a valid request'
+    end
+
+    context 'that receives' do
+      context 'an invalid version in the request' do
+        before {
+          get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v77',
+                           'CONTENT_TYPE' => 'application/json'
+        }
+        it_should_behave_like 'a rescued request'
+      end
+      context 'an invalid vendor in the request' do
+        before {
+          get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.invalidvendor-v99',
+                           'CONTENT_TYPE' => 'application/json'
+        }
+        it_should_behave_like 'a rescued request'
+      end
+    end
+  end
+
+  context 'API with cascade=false and without a rescue handler' do
+    subject { Class.new(Grape::API) }
+    before {
+      subject.version 'v99', using: :header, vendor: 'vendorname', format: :json, cascade: false
+      subject.get '/beer' do
+        'beer received'
+      end
+    }
+
+    def app
+      subject
+    end
+
+    context 'that received a request with correct vendor and version' do
+      before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v99' }
+      it_should_behave_like 'a valid request'
+    end
+
+    context 'that receives' do
+      context 'an invalid version in the request' do
+        before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v77' }
+        it_should_behave_like 'a not-cascaded request'
+      end
+      context 'an invalid vendor in the request' do
+        before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.invalidvendor-v99' }
+        it_should_behave_like 'a not-cascaded request'
+      end
+    end
+  end
+
+  context 'API with cascade=false and with rescue_from :all handler and http_codes' do
+    subject { Class.new(Grape::API) }
+    before {
+      subject.version 'v99', using: :header, vendor: 'vendorname', format: :json, cascade: false
+      subject.rescue_from :all do |e|
+        rack_response 'message was processed', 400, e[:headers]
+      end
+      subject.desc 'Get beer' do
+        failure [[400, 'Bad Request'], [401, 'Unauthorized'], [403, 'Forbidden'],
+                 [404, 'Resource not found'], [406, 'API vendor or version not found'],
+                 [500, 'Internal processing error']]
+      end
+      subject.get '/beer' do
+        'beer received'
+      end
+    }
+
+    def app
+      subject
+    end
+
+    context 'that received a request with correct vendor and version' do
+      before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v99' }
+      it_should_behave_like 'a valid request'
+    end
+
+    context 'that receives' do
+      context 'an invalid version in the request' do
+        before {
+          get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v77',
+                           'CONTENT_TYPE' => 'application/json'
+        }
+        it_should_behave_like 'a rescued request'
+      end
+      context 'an invalid vendor in the request' do
+        before {
+          get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.invalidvendor-v99',
+                           'CONTENT_TYPE' => 'application/json'
+        }
+        it_should_behave_like 'a rescued request'
+      end
+    end
+  end
+
+  context 'API with cascade=false, http_codes but without a rescue handler' do
+    subject { Class.new(Grape::API) }
+    before {
+      subject.version 'v99', using: :header, vendor: 'vendorname', format: :json, cascade: false
+      subject.desc 'Get beer' do
+        failure [[400, 'Bad Request'], [401, 'Unauthorized'], [403, 'Forbidden'],
+                 [404, 'Resource not found'], [406, 'API vendor or version not found'],
+                 [500, 'Internal processing error']]
+      end
+      subject.get '/beer' do
+        'beer received'
+      end
+    }
+
+    def app
+      subject
+    end
+
+    context 'that received a request with correct vendor and version' do
+      before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v99' }
+      it_should_behave_like 'a valid request'
+    end
+
+    context 'that receives' do
+      context 'an invalid version in the request' do
+        before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v77' }
+        it_should_behave_like 'a not-cascaded request'
+      end
+      context 'an invalid vendor in the request' do
+        before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.invalidvendor-v99' }
+        it_should_behave_like 'a not-cascaded request'
+      end
+    end
+  end
+
+  context 'API with cascade=true and rescue_from :all handler' do
+    subject { Class.new(Grape::API) }
+    before {
+      subject.version 'v99', using: :header, vendor: 'vendorname', format: :json, cascade: true
+      subject.rescue_from :all do |e|
+        rack_response 'message was processed', 400, e[:headers]
+      end
+      subject.get '/beer' do
+        'beer received'
+      end
+    }
+
+    def app
+      subject
+    end
+
+    context 'that received a request with correct vendor and version' do
+      before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v99' }
+      it_should_behave_like 'a valid request'
+    end
+
+    context 'that receives' do
+      context 'an invalid version in the request' do
+        before {
+          get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v77',
+                           'CONTENT_TYPE' => 'application/json'
+        }
+        it_should_behave_like 'a cascaded request'
+      end
+      context 'an invalid vendor in the request' do
+        before {
+          get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.invalidvendor-v99',
+                           'CONTENT_TYPE' => 'application/json'
+        }
+        it_should_behave_like 'a cascaded request'
+      end
+    end
+  end
+
+  context 'API with cascade=true and without a rescue handler' do
+    subject { Class.new(Grape::API) }
+    before {
+      subject.version 'v99', using: :header, vendor: 'vendorname', format: :json, cascade: true
+      subject.get '/beer' do
+        'beer received'
+      end
+    }
+
+    def app
+      subject
+    end
+
+    context 'that received a request with correct vendor and version' do
+      before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v99' }
+      it_should_behave_like 'a valid request'
+    end
+
+    context 'that receives' do
+      context 'an invalid version in the request' do
+        before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v77' }
+        it_should_behave_like 'a cascaded request'
+      end
+      context 'an invalid vendor in the request' do
+        before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.invalidvendor-v99' }
+        it_should_behave_like 'a cascaded request'
+      end
+    end
+  end
+
+  context 'API with cascade=true and with rescue_from :all handler and http_codes' do
+    subject { Class.new(Grape::API) }
+    before {
+      subject.version 'v99', using: :header, vendor: 'vendorname', format: :json, cascade: true
+      subject.rescue_from :all do |e|
+        rack_response 'message was processed', 400, e[:headers]
+      end
+      subject.desc 'Get beer' do
+        failure [[400, 'Bad Request'], [401, 'Unauthorized'], [403, 'Forbidden'],
+                 [404, 'Resource not found'], [406, 'API vendor or version not found'],
+                 [500, 'Internal processing error']]
+      end
+      subject.get '/beer' do
+        'beer received'
+      end
+    }
+
+    def app
+      subject
+    end
+
+    context 'that received a request with correct vendor and version' do
+      before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v99' }
+      it_should_behave_like 'a valid request'
+    end
+
+    context 'that receives' do
+      context 'an invalid version in the request' do
+        before {
+          get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v77',
+                           'CONTENT_TYPE' => 'application/json'
+        }
+        it_should_behave_like 'a cascaded request'
+      end
+      context 'an invalid vendor in the request' do
+        before {
+          get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.invalidvendor-v99',
+                           'CONTENT_TYPE' => 'application/json'
+        }
+        it_should_behave_like 'a cascaded request'
+      end
+    end
+  end
+
+  context 'API with cascade=true, http_codes but without a rescue handler' do
+    subject { Class.new(Grape::API) }
+    before {
+      subject.version 'v99', using: :header, vendor: 'vendorname', format: :json, cascade: true
+      subject.desc 'Get beer' do
+        failure [[400, 'Bad Request'], [401, 'Unauthorized'], [403, 'Forbidden'],
+                 [404, 'Resource not found'], [406, 'API vendor or version not found'],
+                 [500, 'Internal processing error']]
+      end
+      subject.get '/beer' do
+        'beer received'
+      end
+    }
+
+    def app
+      subject
+    end
+
+    context 'that received a request with correct vendor and version' do
+      before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v99' }
+      it_should_behave_like 'a valid request'
+    end
+
+    context 'that receives' do
+      context 'an invalid version in the request' do
+        before { get '/beer', {},  'HTTP_ACCEPT' => 'application/vnd.vendorname-v77' }
+        it_should_behave_like 'a cascaded request'
+      end
+      context 'an invalid vendor in the request' do
+        before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.invalidvendor-v99' }
+        it_should_behave_like 'a cascaded request'
+      end
+    end
+  end
+end

--- a/spec/grape/middleware/versioner/header_spec.rb
+++ b/spec/grape/middleware/versioner/header_spec.rb
@@ -84,14 +84,13 @@ describe Grape::Middleware::Versioner::Header do
     end
 
     it 'fails with 406 Not Acceptable if vendor is invalid' do
-      expect do
-        subject.call('HTTP_ACCEPT' => 'application/vnd.othervendor+json').last
-      end.to throw_symbol(
-        :error,
-        status: 406,
-        headers: { 'X-Cascade' => 'pass' },
-        message: 'API vendor or version not found.'
-      )
+      expect { subject.call('HTTP_ACCEPT' => 'application/vnd.othervendor+json').last }
+        .to raise_exception do |exception|
+          expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
+          expect(exception.headers).to eql('X-Cascade' => 'pass')
+          expect(exception.status).to eql 406
+          expect(exception.message).to include 'API vendor or version not found'
+        end
     end
 
     context 'when version is set' do
@@ -112,14 +111,13 @@ describe Grape::Middleware::Versioner::Header do
       end
 
       it 'fails with 406 Not Acceptable if vendor is invalid' do
-        expect do
-          subject.call('HTTP_ACCEPT' => 'application/vnd.othervendor-v1+json').last
-        end.to throw_symbol(
-          :error,
-          status: 406,
-          headers: { 'X-Cascade' => 'pass' },
-          message: 'API vendor or version not found.'
-        )
+        expect { subject.call('HTTP_ACCEPT' => 'application/vnd.othervendor-v1+json').last }
+          .to raise_exception do |exception|
+            expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
+            expect(exception.headers).to eql('X-Cascade' => 'pass')
+            expect(exception.status).to eql 406
+            expect(exception.message).to include('API vendor or version not found')
+          end
       end
     end
   end
@@ -142,14 +140,12 @@ describe Grape::Middleware::Versioner::Header do
     end
 
     it 'fails with 406 Not Acceptable if version is invalid' do
-      expect do
-        subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v2+json').last
-      end.to throw_symbol(
-        :error,
-        status: 406,
-        headers: { 'X-Cascade' => 'pass' },
-        message: 'API vendor or version not found.'
-      )
+      expect { subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v2+json').last }.to raise_exception do |exception|
+        expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
+        expect(exception.headers).to eql('X-Cascade' => 'pass')
+        expect(exception.status).to eql 406
+        expect(exception.message).to include('API vendor or version not found')
+      end
     end
   end
 
@@ -171,47 +167,39 @@ describe Grape::Middleware::Versioner::Header do
     end
 
     it 'fails with 406 Not Acceptable if header is not set' do
-      expect do
-        subject.call({}).last
-      end.to throw_symbol(
-        :error,
-        status: 406,
-        headers: { 'X-Cascade' => 'pass' },
-        message: 'Accept header must be set.'
-      )
+      expect { subject.call({}).last }.to raise_exception do |exception|
+        expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
+        expect(exception.headers).to eql('X-Cascade' => 'pass')
+        expect(exception.status).to eql 406
+        expect(exception.message).to include('Accept header must be set.')
+      end
     end
 
     it 'fails with 406 Not Acceptable if header is empty' do
-      expect do
-        subject.call('HTTP_ACCEPT' => '').last
-      end.to throw_symbol(
-        :error,
-        status: 406,
-        headers: { 'X-Cascade' => 'pass' },
-        message: 'Accept header must be set.'
-      )
+      expect { subject.call('HTTP_ACCEPT' => '').last }.to raise_exception do |exception|
+        expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
+        expect(exception.headers).to eql('X-Cascade' => 'pass')
+        expect(exception.status).to eql 406
+        expect(exception.message).to include('Accept header must be set.')
+      end
     end
 
     it 'fails with 406 Not Acceptable if type is a range' do
-      expect do
-        subject.call('HTTP_ACCEPT' => '*/*').last
-      end.to throw_symbol(
-        :error,
-        status: 406,
-        headers: { 'X-Cascade' => 'pass' },
-        message: 'Accept header must not contain ranges ("*").'
-      )
+      expect { subject.call('HTTP_ACCEPT' => '*/*').last }.to raise_exception do |exception|
+        expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
+        expect(exception.headers).to eql('X-Cascade' => 'pass')
+        expect(exception.status).to eql 406
+        expect(exception.message).to include('Accept header must not contain ranges ("*").')
+      end
     end
 
     it 'fails with 406 Not Acceptable if subtype is a range' do
-      expect do
-        subject.call('HTTP_ACCEPT' => 'application/*').last
-      end.to throw_symbol(
-        :error,
-        status: 406,
-        headers: { 'X-Cascade' => 'pass' },
-        message: 'Accept header must not contain ranges ("*").'
-      )
+      expect { subject.call('HTTP_ACCEPT' => 'application/*').last }.to raise_exception do |exception|
+        expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
+        expect(exception.headers).to eql('X-Cascade' => 'pass')
+        expect(exception.status).to eql 406
+        expect(exception.message).to include('Accept header must not contain ranges ("*").')
+      end
     end
 
     it 'succeeds if proper header is set' do
@@ -227,47 +215,39 @@ describe Grape::Middleware::Versioner::Header do
     end
 
     it 'fails with 406 Not Acceptable if header is not set' do
-      expect do
-        subject.call({}).last
-      end.to throw_symbol(
-        :error,
-        status: 406,
-        headers: {},
-        message: 'Accept header must be set.'
-      )
+      expect { subject.call({}).last }.to raise_exception do |exception|
+        expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
+        expect(exception.headers).to eql({})
+        expect(exception.status).to eql 406
+        expect(exception.message).to include('Accept header must be set.')
+      end
     end
 
     it 'fails with 406 Not Acceptable if header is empty' do
-      expect do
-        subject.call('HTTP_ACCEPT' => '').last
-      end.to throw_symbol(
-        :error,
-        status: 406,
-        headers: {},
-        message: 'Accept header must be set.'
-      )
+      expect { subject.call('HTTP_ACCEPT' => '').last }.to raise_exception do |exception|
+        expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
+        expect(exception.headers).to eql({})
+        expect(exception.status).to eql 406
+        expect(exception.message).to include('Accept header must be set.')
+      end
     end
 
     it 'fails with 406 Not Acceptable if type is a range' do
-      expect do
-        subject.call('HTTP_ACCEPT' => '*/*').last
-      end.to throw_symbol(
-        :error,
-        status: 406,
-        headers: {},
-        message: 'Accept header must not contain ranges ("*").'
-      )
+      expect { subject.call('HTTP_ACCEPT' => '*/*').last }.to raise_exception do |exception|
+        expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
+        expect(exception.headers).to eql({})
+        expect(exception.status).to eql 406
+        expect(exception.message).to include('Accept header must not contain ranges ("*").')
+      end
     end
 
     it 'fails with 406 Not Acceptable if subtype is a range' do
-      expect do
-        subject.call('HTTP_ACCEPT' => 'application/*').last
-      end.to throw_symbol(
-        :error,
-        status: 406,
-        headers: {},
-        message: 'Accept header must not contain ranges ("*").'
-      )
+      expect { subject.call('HTTP_ACCEPT' => 'application/*').last }.to raise_exception do |exception|
+        expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
+        expect(exception.headers).to eql({})
+        expect(exception.status).to eql 406
+        expect(exception.message).to include('Accept header must not contain ranges ("*").')
+      end
     end
 
     it 'succeeds if proper header is set' do
@@ -289,14 +269,12 @@ describe Grape::Middleware::Versioner::Header do
     end
 
     it 'fails with another version' do
-      expect do
-        subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v3+json')
-      end.to throw_symbol(
-        :error,
-        status: 406,
-        headers: { 'X-Cascade' => 'pass' },
-        message: 'API vendor or version not found.'
-      )
+      expect { subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v3+json') }.to raise_exception do |exception|
+        expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
+        expect(exception.headers).to eql('X-Cascade' => 'pass')
+        expect(exception.status).to eql 406
+        expect(exception.message).to include('API vendor or version not found')
+      end
     end
   end
 end


### PR DESCRIPTION
Fixed that invalid accept headers are (1) not processed by rescue handlers and (2) result in status 500 (no method) when http_codes are defined. The fix is based on changing the former `throw` to raising a new error, which then can be processed.

**To (1):**  
The actual behavior of cascading the request remains unchanged as the headers are included in the raised error. As long as the error is not rescued it results in the same error messages (404 or 406).
The error message that is generated consists of two parts: The problem `Invalid accept header` and what actually went wrong, eg. `API vendor or version not found`. The cause of the problem was included as the resolution of the problem, as it always describes what the user did wrong:
- Accept header must be set
- Accept header must not contain ranges ("*")
- 406 Not Acceptable <-- not quite perfect, shouldn't it be *No matching media type found* ?
- API vendor or version not found
- *The error message when `Rack::Accept::MediaType.new env['HTTP_ACCEPT']` fails*

**To (2):**  
As commented in the source code, `lib/grape/error_formatter/base.rb` does raise an error if the failure originated from the middleware and not a route. All the `throw` statements that were used before have caused those errors if http_codes were defined in the route description.

Please let me know if there are any issues with these changes.
Cedric