### PR TITLE
Reset endpoint options between calls

### DIFF
--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -324,5 +324,10 @@ module Grape
     def afters
       namespace_stackable(:afters) || []
     end
+
+    def initialize_copy(other)
+      super
+      self.options = other.options.deep_dup
+    end
   end
 end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -766,6 +766,19 @@ describe Grape::Endpoint do
     expect(last_response.body).to eq('Hello')
   end
 
+  it 'reset options between calls' do
+    subject.get('/options') do
+      if params[:rabl]
+        env['api.endpoint'].options[:route_options][:rabl] = params[:rabl]
+      end
+    end
+
+    get '/options?rabl=index'
+    expect(last_request.env['api.endpoint'].options[:route_options][:rabl]).to eq 'index'
+    get '/options'
+    expect(last_request.env['api.endpoint'].options[:route_options][:rabl]).to eq nil
+  end
+
   describe '.generate_api_method' do
     it 'raises NameError if the method name is already in use' do
       expect do


### PR DESCRIPTION
I'm using Grape and Rable with grape-rabl gem, I have following code:
```ruby
class Comments < Grape::API
  resources :comments do
    post do
      comment = Comment.new(params)
      if comment.save
        render rabl: 'comments/show'
      else
        car.errors.to_hash
      end
    end
  end
end
```
When first request save the comment succesfully, whatever the nex request save the comment succesfully or not, the rabl template will alway be rendered. Because  grape-rabl write the template info to the endpoint options (https://github.com/LTe/grape-rabl/blob/master/lib%2Fgrape-rabl%2Frender.rb#L4), so I thinks the endpoint options should be reset between calls. 