### PR TITLE
merge options and block

### DIFF
--- a/lib/grape/dsl/configuration.rb
+++ b/lib/grape/dsl/configuration.rb
@@ -28,7 +28,7 @@ module Grape
             end
 
             config_class.configure(&config_block)
-            options = config_class.settings
+            options = options.merge(config_class.settings)
           else
             options = options.merge(description: description)
           end

--- a/spec/grape/dsl/configuration_spec.rb
+++ b/spec/grape/dsl/configuration_spec.rb
@@ -70,6 +70,22 @@ module Grape
           expect(subject.namespace_setting(:description)).to eq(expected_options)
           expect(subject.route_setting(:description)).to eq(expected_options)
         end
+
+        it 'can merge options and block' do
+          expected_options = {
+            description: 'The description',
+            detail: 'more details',
+            params: { first: :param },
+            authorizations: { oauth2: [] }
+          }
+          subject.desc 'The description', authorizations: { oauth2: [] } do
+            detail 'more details'
+            params(first: :param)
+          end
+
+          expect(subject.namespace_setting(:description)).to eq(expected_options)
+          expect(subject.route_setting(:description)).to eq(expected_options)
+        end
       end
     end
   end


### PR DESCRIPTION
When using [wine_bouncer](https://github.com/antek-drzewiecki/wine_bouncer) gem, 
I have to use `authorizations` options in `desc` method like this:

```ruby
   desc 'protected method with required public scope',
   authorizations: { oauth2: [{ scope: 'public' }] }
   get '/protected' do
      { hello: 'world' }
   end
```

but any options will be ignored if I use `desc` method with block like this:

```ruby
   desc 'protected method with required public scope',
   authorizations: { oauth2: [{ scope: 'public' }] } do
     success Entity::Hello
   end
   get '/protected' do
      { hello: 'world' }
   end
```

So I want to merge options and block.
If you think it is not good, I want some easy way to add DSL method like `authorizations` in `desc` block.
`desc_container` is difficult for hack.

```ruby
   desc 'protected method with required public scope' do
     authorizations oauth2: [{ scope: 'public' }]      # add hash configuration
     oauth2 scope: 'public'                                     # and/or add wrapper like `success`
     success Entity::Hello
   end
   get '/protected' do
      { hello: 'world' }
   end
```