### PR TITLE
Add test to reproduce bug with Warden test helper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ group :development, :test do
   gem 'guard'
   gem 'guard-rspec'
   gem 'guard-rubocop'
+  gem 'warden', '~> 1.2.3'
 end

--- a/lib/grape/util/inheritable_values.rb
+++ b/lib/grape/util/inheritable_values.rb
@@ -36,7 +36,7 @@ module Grape
       def initialize_copy(other)
         super
         self.inherited_values = other.inherited_values
-        self.new_values = other.new_values.deep_dup
+        self.new_values = other.new_values.dup
       end
 
       protected

--- a/lib/grape/util/stackable_values.rb
+++ b/lib/grape/util/stackable_values.rb
@@ -45,7 +45,7 @@ module Grape
       def initialize_copy(other)
         super
         self.inherited_values = other.inherited_values
-        self.new_values = other.new_values.deep_dup
+        self.new_values = other.new_values.dup
       end
     end
   end

--- a/spec/grape/warden_test_helpers_spec.rb
+++ b/spec/grape/warden_test_helpers_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+FailureApp = ->(env) { [401, {}, ['']] }
+
+class APIEvaluatedBeforeTests < Grape::API
+  use(Warden::Manager) { |manager| manager.failure_app = FailureApp }
+
+  before { env.fetch('warden').authenticate! }
+
+  get '/'
+end
+
+describe Warden::Test::Helpers do
+  def app
+    subject
+  end
+
+  describe '#login_as' do
+    before { login_as(:user) }
+
+    context 'API evaluated before tests' do
+      subject { APIEvaluatedBeforeTests }
+
+      it 'logs in' do
+        get '/'
+        expect(last_response).to be_ok
+      end
+    end
+
+    context 'API evaluated after tests' do
+      let(:api_evaluated_after_tests) do
+        Class.new(Grape::API) do
+          use(Warden::Manager) { |manager| manager.failure_app = FailureApp }
+
+          before { env.fetch('warden').authenticate! }
+
+          get '/'
+        end
+      end
+
+      subject { api_evaluated_after_tests }
+
+      it 'logs in' do
+        get '/'
+        expect(last_response).to be_ok
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ require 'base64'
 require 'cookiejar'
 require 'json'
 require 'mime/types'
+require 'warden'
 
 Dir["#{File.dirname(__FILE__)}/support/*.rb"].each do |file|
   require file
@@ -23,7 +24,10 @@ I18n.enforce_available_locales = false
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods
+  config.include Warden::Test::Helpers
   config.raise_errors_for_deprecations!
+
+  config.after(:each) { Warden.test_reset! }
 
   config.before(:each) { Grape::Util::InheritableSetting.reset_global! }
 end


### PR DESCRIPTION
When using the `login_as` Warden test helper, it depends whether or not the API class under test is evaluated *before* or *after* the tests.

Given that this bug first appeared in [v0.10.0](https://github.com/intridea/grape/releases/tag/v0.10.0), my current theory is the use of `deep_dup` is responsible. Warden persists registered hooks in [instance variables](http://git.io/NhKG). When an API class is evaluated *before* the tests, the hooks are registered *after* duplication takes place, so the original object is left with an empty array of hooks.

Any help or suggestions are most appreciated. Thanks for this great library! :smile: 