### PR TITLE
fix weird behaviour for optional groups with default params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 0.11.1 (Next)
 =============
 
+#### Fixes
+
+* [#936](https://github.com/intridea/grape/pull/936): Fixed default params processing for optional groups - [@dm1try](https://github.com/dm1try).
+
 * Your contribution here.
 
 0.11.0 (2/23/2015)

--- a/lib/grape/validations/validators/default.rb
+++ b/lib/grape/validations/validators/default.rb
@@ -11,12 +11,12 @@ module Grape
       end
 
       def validate!(params)
+        return unless @scope.should_validate?(params)
+
         attrs = AttributesIterator.new(self, @scope, params)
-        parent_element = @scope.element
         attrs.each do |resource_params, attr_name|
           if resource_params[attr_name].nil?
             validate_param!(attr_name, resource_params)
-            params[parent_element] = resource_params if parent_element && params[parent_element].nil?
           end
         end
       end


### PR DESCRIPTION
apply defaults for inner params only if parent param is present

fixes #615 (see for more info)

/cc @dblock  take a look