### PR TITLE
Pass thru the Error .status value when using rescue_from :all

### DIFF
--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -59,7 +59,7 @@ module Grape
       end
 
       def handle_error(e)
-        error_response(message: e.message, backtrace: e.backtrace)
+        error_response(message: e.message, backtrace: e.backtrace, status: e.try(:status))
       end
 
       def error_response(error = {})

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -59,7 +59,8 @@ module Grape
       end
 
       def handle_error(e)
-        error_response(message: e.message, backtrace: e.backtrace, status: e.try(:status))
+        status = (e.respond_to?(:status) && e.status.is_a?(Integer)) ? e.status : nil
+        error_response(message: e.message, backtrace: e.backtrace, status: status)
       end
 
       def error_response(error = {})

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1265,6 +1265,20 @@ describe Grape::API do
       expect(last_response.status).to eql 420
     end
 
+    it ':all does not pass thru non-Integer status codes' do
+      class ErrorWithBadStatusMethod < StandardError
+        def status
+          'foo'
+        end
+      end
+      subject.rescue_from :all
+      subject.get '/exception' do
+        fail ErrorWithBadStatusMethod
+      end
+      get '/exception'
+      expect(last_response.status).to eql 500
+    end
+
     it 'rescues all errors with a json formatter' do
       subject.format :json
       subject.default_format :json

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1251,6 +1251,20 @@ describe Grape::API do
       expect(last_response.body).to eq 'rain!'
     end
 
+    it ':all respects the status code of the error object' do
+      class ErrorWithHttpStatus < StandardError
+        def status
+          420
+        end
+      end
+      subject.rescue_from :all
+      subject.get '/exception' do
+        fail ErrorWithHttpStatus
+      end
+      get '/exception'
+      expect(last_response.status).to eql 420
+    end
+
     it 'rescues all errors with a json formatter' do
       subject.format :json
       subject.default_format :json


### PR DESCRIPTION
This fixes #938 by checking to see if the Error object passed down to error_response has a :status method that returns an Integer.  If so, the value is passed into error_response by handle_error to set the http status code vs the default of 500.   This fixes a situation where a validation error will return as a 500 status due to `rescue_from :all` without an attached block handler.