### PR TITLE
Fix: Operate on a cloned Hash when specifying param presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 #### Fixes
 
 * [#936](https://github.com/intridea/grape/pull/936): Fixed default params processing for optional groups - [@dm1try](https://github.com/dm1try).
+* [#](https://github.com/intridea/grape/pull/): Fixed forced presence for optional params when based on a reused entity that was also required in another context - [@croeck](https://github.com/croeck).
 
 * Your contribution here.
 

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -21,7 +21,7 @@ module Grape
       def requires(*attrs, &block)
         orig_attrs = attrs.clone
 
-        opts = attrs.last.is_a?(Hash) ? attrs.pop : {}
+        opts = attrs.last.is_a?(Hash) ? attrs.pop.clone : {}
         opts.merge!(presence: true)
 
         if opts[:using]
@@ -37,7 +37,7 @@ module Grape
       def optional(*attrs, &block)
         orig_attrs = attrs.clone
 
-        opts = attrs.last.is_a?(Hash) ? attrs.pop : {}
+        opts = attrs.last.is_a?(Hash) ? attrs.pop.clone : {}
         type = opts[:type]
 
         # check type for optional parameter group

--- a/spec/grape/validations/validators/presence_spec.rb
+++ b/spec/grape/validations/validators/presence_spec.rb
@@ -176,4 +176,42 @@ describe Grape::Validations::PresenceValidator do
       expect(last_response.body).to eq('Nested triple'.to_json)
     end
   end
+
+  context 'with reused parameter documentation once required and once optional' do
+    before do
+      docs = { name: { type: String, desc: 'some name' } }
+
+      subject.params do
+        requires :all, using: docs
+      end
+      subject.get '/required' do
+        'Hello required'
+      end
+
+      subject.params do
+        optional :all, using: docs
+      end
+      subject.get '/optional' do
+        'Hello optional'
+      end
+    end
+    it 'works with required' do
+      get '/required'
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('{"error":"name is missing"}')
+
+      get '/required', name: 'Bob'
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq('Hello required'.to_json)
+    end
+    it 'works with optional' do
+      get '/optional'
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq('Hello optional'.to_json)
+
+      get '/optional', name: 'Bob'
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq('Hello optional'.to_json)
+    end
+  end
 end


### PR DESCRIPTION
Operate on a cloned Hash when specifying `presence: true` for parameters to prevent issues with re-used entities. Includes spec and the minor fix.

Should be self explaining this time :)