### PR TITLE
Fix: route_param cannot accept string that contains a period, interprets it as a format extension

### DIFF
--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -177,7 +177,6 @@ module Grape
       endpoint_options = {}
       endpoint_options[:version] = /#{namespace_inheritable(:version).join('|')}/ if namespace_inheritable(:version)
       endpoint_options.merge!(requirements)
-
       Rack::Mount::Strexp.compile(prepared_path.to_s, endpoint_options, prepared_path.route_param_illegal_chars, anchor)
     end
 

--- a/lib/grape/path.rb
+++ b/lib/grape/path.rb
@@ -1,9 +1,5 @@
 module Grape
   class Path
-    def self.prepare(raw_path, namespace, settings)
-      Path.new(raw_path, namespace, settings).path_with_suffix
-    end
-
     attr_reader :raw_path, :namespace, :settings
 
     def initialize(raw_path, namespace, settings)
@@ -43,6 +39,14 @@ module Grape
         '(.:format)'
       else
         '(/.:format)'
+      end
+    end
+
+    def route_param_illegal_chars
+      if uses_specific_format?
+        %w( / ? )
+      else
+        %w( / . ? )
       end
     end
 

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -249,6 +249,25 @@ describe Grape::API do
       get '/users/23'
       expect(last_response.status).to eq(200)
     end
+
+    context 'only support JSON format' do
+      before(:each) do
+        subject.format :json
+      end
+
+      it 'should pass along full string parameter containing an "extension"' do
+        subject.namespace :domains do
+          route_param :domain do
+            get do
+              params[:domain]
+            end
+          end
+        end
+
+        get '/domains/example.com'
+        expect(last_response.body).to eq('example.com'.to_json)
+      end
+    end
   end
 
   describe '.route' do

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -253,6 +253,7 @@ describe Grape::API do
     context 'only support JSON format' do
       before(:each) do
         subject.format :json
+        subject.content_type :json, 'application/json'
       end
 
       it 'should pass along full string parameter containing an "extension"' do

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -253,7 +253,6 @@ describe Grape::API do
     context 'only support JSON format' do
       before(:each) do
         subject.format :json
-        subject.content_type :json, 'application/json'
       end
 
       it 'should pass along full string parameter containing an "extension"' do


### PR DESCRIPTION
When a Grape::API is set to support just a single format (e.g. `format :json`), it does not need URL extensions to specify the format of a request. Under such conditions, it should be possible to pass a string value that contains a period (.) to a `route_param`, which would otherwise be recognized as a format extension.