### PR TITLE
Update README with new MiniTest base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -2297,7 +2297,7 @@ end
 ```ruby
 require "test_helper"
 
-class Twitter::APITest < MiniTest::Unit::TestCase
+class Twitter::APITest < MiniTest::Test
   include Rack::Test::Methods
 
   def app


### PR DESCRIPTION
Minitest 5.0 renamed `MiniTest::Unit::TestCase` to `Minitest::Test`.