### PR TITLE
Add routing specs

### DIFF
--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -134,7 +134,7 @@ module Grape
           end
         end
 
-        def namespace(space = nil, options = {},  &block)
+        def namespace(space = nil, options = {}, &block)
           if space || block_given?
             within_namespace do
               previous_namespace_description = @namespace_description

--- a/spec/grape/dsl/routing_spec.rb
+++ b/spec/grape/dsl/routing_spec.rb
@@ -121,20 +121,28 @@ module Grape
         it 'does some thing'
       end
 
-      xdescribe '.group' do
-        it 'does some thing'
+      describe '.group' do
+        it 'is alias to #namespace' do
+          expect(subject.method(:group)).to eq subject.method(:namespace)
+        end
       end
 
-      xdescribe '.resource' do
-        it 'does some thing'
+      describe '.resource' do
+        it 'is alias to #namespace' do
+          expect(subject.method(:resource)).to eq subject.method(:namespace)
+        end
       end
 
-      xdescribe '.resources' do
-        it 'does some thing'
+      describe '.resources' do
+        it 'is alias to #namespace' do
+          expect(subject.method(:resources)).to eq subject.method(:namespace)
+        end
       end
 
-      xdescribe '.segment' do
-        it 'does some thing'
+      describe '.segment' do
+        it 'is alias to #namespace' do
+          expect(subject.method(:segment)).to eq subject.method(:namespace)
+        end
       end
 
       xdescribe '.routes' do

--- a/spec/grape/dsl/routing_spec.rb
+++ b/spec/grape/dsl/routing_spec.rb
@@ -152,8 +152,24 @@ module Grape
         end
       end
 
-      xdescribe '.namespace' do
-        it 'does some thing'
+      describe '.namespace' do
+        let(:new_namespace) { Object.new }
+
+        it 'creates a new namespace with given name and options' do
+          expect(subject).to receive(:within_namespace).and_yield
+          expect(subject).to receive(:nest).and_yield
+          expect(Namespace).to receive(:new).with(:foo, foo: 'bar').and_return(new_namespace)
+          expect(subject).to receive(:namespace_stackable).with(:namespace, new_namespace)
+
+          subject.namespace :foo, foo: 'bar', &proc{}
+        end
+
+        it 'calls #joined_space_path on Namespace' do
+          result_of_namspace_stackable = Object.new
+          allow(subject).to receive(:namespace_stackable).and_return(result_of_namspace_stackable)
+          expect(Namespace).to receive(:joined_space_path).with(result_of_namspace_stackable)
+          subject.namespace
+        end
       end
 
       describe '.group' do

--- a/spec/grape/dsl/routing_spec.rb
+++ b/spec/grape/dsl/routing_spec.rb
@@ -165,8 +165,26 @@ module Grape
         end
       end
 
-      xdescribe '.route_param' do
-        it 'does some thing'
+      describe '.route_param' do
+        it 'calls #namespace with given params' do
+          expect(subject).to receive(:namespace).with(':foo', {}).and_yield
+          subject.route_param('foo', {}, &proc{})
+        end
+
+        let(:regex) { /(.*)/ }
+        let!(:options) {  { requirements: regex } }
+        it 'nests requirements option under param name' do
+          expect(subject).to receive(:namespace) do |param, options|
+            expect(options[:requirements][:foo]).to eq regex
+          end
+          subject.route_param('foo', options, &proc{})
+        end
+
+        it 'does not modify options parameter' do
+          allow(subject).to receive(:namespace)
+          expect { subject.route_param('foo', options, &proc{}) }
+            .to_not change { options }
+        end
       end
 
       describe '.versions' do

--- a/spec/grape/dsl/routing_spec.rb
+++ b/spec/grape/dsl/routing_spec.rb
@@ -145,8 +145,24 @@ module Grape
         end
       end
 
-      xdescribe '.routes' do
-        it 'does some thing'
+      describe '.routes' do
+        let(:routes) { Object.new }
+
+        it 'returns value received from #prepare_routes' do
+          expect(subject).to receive(:prepare_routes).and_return(routes)
+          expect(subject.routes).to eq routes
+        end
+
+        context 'when #routes was already called once' do
+          before do
+            allow(subject).to receive(:prepare_routes).and_return(routes)
+            subject.routes
+          end
+          it 'it does not call prepare_routes again' do
+            expect(subject).to_not receive(:prepare_routes)
+            expect(subject.routes).to eq routes
+          end
+        end
       end
 
       xdescribe '.route_param' do


### PR DESCRIPTION
Add pending specs for Routing module. Merging this PR will close #874.

Added specs for following methods:
- group
- resource
- resources
- segment
- namespace
- routes
- route_param
- route
