### PR TITLE
Allow symbols for status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * [#936](https://github.com/intridea/grape/pull/936): Fixed default params processing for optional groups - [@dm1try](https://github.com/dm1try).
 * [#942](https://github.com/intridea/grape/pull/942): Fixed forced presence for optional params when based on a reused entity that was also required in another context - [@croeck](https://github.com/croeck).
+* [#950](https://github.com/intridea/grape/pull/950): Status method can now accept one of Rack::Utils status code symbols (:ok, :found, :bad_request, etc.). - [@dabrorius](https://github.com/dabrorius).
 
 * Your contribution here.
 

--- a/README.md
+++ b/README.md
@@ -352,6 +352,14 @@ post do
 end
 ```
 
+You can also use one of status codes symbols that are provided by [Rack utils](http://www.rubydoc.info/github/rack/rack/Rack/Utils#HTTP_STATUS_CODES-constant)
+
+```ruby
+post do
+  status :no_content
+end
+```
+
 ### Accept-Version Header
 
 ```ruby

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -94,7 +94,13 @@ module Grape
       #
       # @param status [Integer] The HTTP Status Code to return for this request.
       def status(status = nil)
-        if status
+        if status.is_a? Symbol
+          if Rack::Utils::SYMBOL_TO_STATUS_CODE.keys.include?(status)
+            @status = Rack::Utils.status_code(status)
+          else
+            fail ArgumentError, "Status code :#{status} is invalid."
+          end
+        elsif status
           @status = status
         else
           return @status if @status

--- a/spec/grape/dsl/inside_route_spec.rb
+++ b/spec/grape/dsl/inside_route_spec.rb
@@ -107,6 +107,16 @@ module Grape
           subject.status 501
           expect(subject.status).to eq 501
         end
+
+        it 'accepts symbol for status' do
+          subject.status :see_other
+          expect(subject.status).to eq 303
+        end
+
+        it 'raises error if unknow symbol is passed' do
+          expect { subject.status :foo_bar }
+            .to raise_error(ArgumentError, 'Status code :foo_bar is invalid.')
+        end
       end
 
       describe '#header' do


### PR DESCRIPTION
This is a very simple implementation of feature requested in #934.