### PR TITLE
Raise error if unknow status code is passed to #status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#936](https://github.com/intridea/grape/pull/936): Fixed default params processing for optional groups - [@dm1try](https://github.com/dm1try).
 * [#942](https://github.com/intridea/grape/pull/942): Fixed forced presence for optional params when based on a reused entity that was also required in another context - [@croeck](https://github.com/croeck).
 * [#950](https://github.com/intridea/grape/pull/950): Status method can now accept one of Rack::Utils status code symbols (:ok, :found, :bad_request, etc.). - [@dabrorius](https://github.com/dabrorius).
+* [#952](https://github.com/intridea/grape/pull/952): Status method now raises error when called with invalid status code. - [@dabrorius](https://github.com/dabrorius).
 
 * Your contribution here.
 

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -94,15 +94,20 @@ module Grape
       #
       # @param status [Integer] The HTTP Status Code to return for this request.
       def status(status = nil)
-        if status.is_a? Symbol
+        case status
+        when Symbol
           if Rack::Utils::SYMBOL_TO_STATUS_CODE.keys.include?(status)
             @status = Rack::Utils.status_code(status)
           else
             fail ArgumentError, "Status code :#{status} is invalid."
           end
-        elsif status
-          @status = status
-        else
+        when Fixnum
+          if Rack::Utils::HTTP_STATUS_CODES.keys.include?(status)
+            @status = status
+          else
+            fail ArgumentError, "Status code #{status} is invalid."
+          end
+        when nil
           return @status if @status
           case request.request_method.to_s.upcase
           when 'POST'
@@ -110,6 +115,8 @@ module Grape
           else
             200
           end
+        else
+          fail ArgumentError, 'Status code must be Fixnum or Symbol.'
         end
       end
 

--- a/spec/grape/dsl/inside_route_spec.rb
+++ b/spec/grape/dsl/inside_route_spec.rb
@@ -117,6 +117,16 @@ module Grape
           expect { subject.status :foo_bar }
             .to raise_error(ArgumentError, 'Status code :foo_bar is invalid.')
         end
+
+        it 'raises error if unknow status code is passed' do
+          expect { subject.status 210 }
+            .to raise_error(ArgumentError, 'Status code 210 is invalid.')
+        end
+
+        it 'raises error if status is not a fixnum or symbol' do
+          expect { subject.status Object.new }
+            .to raise_error(ArgumentError, 'Status code must be Fixnum or Symbol.')
+        end
       end
 
       describe '#header' do


### PR DESCRIPTION
- Raise error if given status code is not included Rack::HTTP_STATUS_CODES
- Raise error if given status is not a Fixnum or Symbol