### PR TITLE
Less allocated objects on each request

### DIFF
--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -42,6 +42,10 @@ module Grape
   autoload :Validations,         'grape/validations'
   autoload :Request,             'grape/http/request'
 
+  module Http
+    autoload :Headers,           'grape/http/headers'
+  end
+
   module Exceptions
     autoload :Base,                           'grape/exceptions/base'
     autoload :Validation,                     'grape/exceptions/validation'

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -96,7 +96,7 @@ module Grape
 
     def call(env)
       result = @route_set.call(env)
-      result[1].delete('X-Cascade') unless cascade?
+      result[1].delete(Grape::Http::Headers::X_CASCADE) unless cascade?
       result
     end
 
@@ -142,12 +142,12 @@ module Grape
           methods_per_path.each do |path, methods|
             allowed_methods = methods.dup
             unless self.class.namespace_inheritable(:do_not_route_head)
-              allowed_methods |= ['HEAD'] if allowed_methods.include?('GET')
+              allowed_methods |= [Grape::Http::Headers::HEAD] if allowed_methods.include?(Grape::Http::Headers::GET)
             end
 
-            allow_header = (['OPTIONS'] | allowed_methods).join(', ')
+            allow_header = ([Grape::Http::Headers::OPTIONS] | allowed_methods).join(', ')
             unless self.class.namespace_inheritable(:do_not_route_options)
-              unless allowed_methods.include?('OPTIONS')
+              unless allowed_methods.include?(Grape::Http::Headers::OPTIONS)
                 self.class.options(path, {}) do
                   header 'Allow', allow_header
                   status 204
@@ -157,7 +157,7 @@ module Grape
             end
 
             not_allowed_methods = %w(GET PUT POST DELETE PATCH HEAD) - allowed_methods
-            not_allowed_methods << 'OPTIONS' if self.class.namespace_inheritable(:do_not_route_options)
+            not_allowed_methods << Grape::Http::Headers::OPTIONS if self.class.namespace_inheritable(:do_not_route_options)
             self.class.route(not_allowed_methods, path) do
               header 'Allow', allow_header
               status 405

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -80,7 +80,7 @@ module Grape
         if merged_options[:permanent]
           status 301
         else
-          if env['HTTP_VERSION'] == 'HTTP/1.1' && request.request_method.to_s.upcase != 'GET'
+          if env[Grape::Http::Headers::HTTP_VERSION] == 'HTTP/1.1' && request.request_method.to_s.upcase != Grape::Http::Headers::GET
             status 303
           else
             status 302
@@ -106,7 +106,7 @@ module Grape
         when nil
           return @status if @status
           case request.request_method.to_s.upcase
-          when 'POST'
+          when Grape::Http::Headers::POST
             201
           else
             200
@@ -129,9 +129,9 @@ module Grape
       # Set response content-type
       def content_type(val = nil)
         if val
-          header('Content-Type', val)
+          header(Grape::Http::Headers::CONTENT_TYPE, val)
         else
-          header['Content-Type']
+          header[Grape::Http::Headers::CONTENT_TYPE]
         end
       end
 

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -106,8 +106,8 @@ module Grape
 
         routes.each do |route|
           methods = [route.route_method]
-          if !namespace_inheritable(:do_not_route_head) && route.route_method == 'GET'
-            methods << 'HEAD'
+          if !namespace_inheritable(:do_not_route_head) && route.route_method == Grape::Http::Headers::GET
+            methods << Grape::Http::Headers::HEAD
           end
           methods.each do |method|
             route_set.add_route(self, {

--- a/lib/grape/http/headers.rb
+++ b/lib/grape/http/headers.rb
@@ -1,0 +1,27 @@
+module Grape
+  module Http
+    module Headers
+      # https://github.com/rack/rack/blob/master/lib/rack.rb
+      HTTP_VERSION    = 'HTTP_VERSION'.freeze
+      PATH_INFO       = 'PATH_INFO'.freeze
+      QUERY_STRING    = 'QUERY_STRING'.freeze
+      CONTENT_TYPE    = 'Content-Type'.freeze
+
+      GET     = 'GET'.freeze
+      POST    = 'POST'.freeze
+      PUT     = 'PUT'.freeze
+      PATCH   = 'PATCH'.freeze
+      DELETE  = 'DELETE'.freeze
+      HEAD    = 'HEAD'.freeze
+      OPTIONS = 'OPTIONS'.freeze
+
+      HTTP_ACCEPT_VERSION    = 'HTTP_ACCEPT_VERSION'.freeze
+      X_CASCADE              = 'X-Cascade'.freeze
+      HTTP_TRANSFER_ENCODING = 'HTTP_TRANSFER_ENCODING'.freeze
+      HTTP_ACCEPT            = 'HTTP_ACCEPT'.freeze
+
+      ACCEPT                 = 'accept'.freeze
+      FORMAT                 = 'format'.freeze
+    end
+  end
+end

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -59,7 +59,7 @@ module Grape
       end
 
       def error!(message, status = options[:default_status], headers = {}, backtrace = [])
-        headers = { 'Content-Type' => content_type }.merge(headers)
+        headers = { Grape::Http::Headers::CONTENT_TYPE => content_type }.merge(headers)
         rack_response(format_message(message, backtrace), status, headers)
       end
 
@@ -71,13 +71,13 @@ module Grape
       def error_response(error = {})
         status = error[:status] || options[:default_status]
         message = error[:message] || options[:default_message]
-        headers = { 'Content-Type' => content_type }
+        headers = { Grape::Http::Headers::CONTENT_TYPE => content_type }
         headers.merge!(error[:headers]) if error[:headers].is_a?(Hash)
         backtrace = error[:backtrace] || []
         rack_response(format_message(message, backtrace), status, headers)
       end
 
-      def rack_response(message, status = options[:default_status], headers = { 'Content-Type' => content_type })
+      def rack_response(message, status = options[:default_status], headers = { Grape::Http::Headers::CONTENT_TYPE => content_type })
         Rack::Response.new([message], status, headers).finish
       end
 

--- a/lib/grape/middleware/versioner/accept_version_header.rb
+++ b/lib/grape/middleware/versioner/accept_version_header.rb
@@ -18,7 +18,7 @@ module Grape
       # route.
       class AcceptVersionHeader < Base
         def before
-          potential_version = (env['HTTP_ACCEPT_VERSION'] || '').strip
+          potential_version = (env[Grape::Http::Headers::HTTP_ACCEPT_VERSION] || '').strip
 
           if strict?
             # If no Accept-Version header:
@@ -59,7 +59,7 @@ module Grape
         end
 
         def error_headers
-          cascade? ? { 'X-Cascade' => 'pass' } : {}
+          cascade? ? { Grape::Http::Headers::X_CASCADE => 'pass' } : {}
         end
       end
     end

--- a/lib/grape/middleware/versioner/header.rb
+++ b/lib/grape/middleware/versioner/header.rb
@@ -84,7 +84,7 @@ module Grape
         end
 
         def rack_accept_header
-          Rack::Accept::MediaType.new env['HTTP_ACCEPT']
+          Rack::Accept::MediaType.new env[Grape::Http::Headers::HTTP_ACCEPT]
         rescue RuntimeError => e
           raise Grape::Exceptions::InvalidAcceptHeader.new(e.message, error_headers)
         end
@@ -113,7 +113,7 @@ module Grape
         end
 
         def error_headers
-          cascade? ? { 'X-Cascade' => 'pass' } : {}
+          cascade? ? { Grape::Http::Headers::X_CASCADE => 'pass' } : {}
         end
 
         # @param [String] media_type a content type

--- a/lib/grape/middleware/versioner/param.rb
+++ b/lib/grape/middleware/versioner/param.rb
@@ -27,10 +27,10 @@ module Grape
 
         def before
           paramkey = options[:parameter]
-          potential_version = Rack::Utils.parse_nested_query(env['QUERY_STRING'])[paramkey]
+          potential_version = Rack::Utils.parse_nested_query(env[Grape::Http::Headers::QUERY_STRING])[paramkey]
           unless potential_version.nil?
             if options[:versions] && !options[:versions].find { |v| v.to_s == potential_version }
-              throw :error, status: 404, message: '404 API Version Not Found', headers: { 'X-Cascade' => 'pass' }
+              throw :error, status: 404, message: '404 API Version Not Found', headers: { Grape::Http::Headers::X_CASCADE => 'pass' }
             end
             env['api.version'] = potential_version
             env['rack.request.query_hash'].delete(paramkey) if env.key? 'rack.request.query_hash'

--- a/lib/grape/middleware/versioner/path.rb
+++ b/lib/grape/middleware/versioner/path.rb
@@ -24,7 +24,7 @@ module Grape
         end
 
         def before
-          path = env['PATH_INFO'].dup
+          path = env[Grape::Http::Headers::PATH_INFO].dup
 
           if prefix && path.index(prefix) == 0
             path.sub!(prefix, '')


### PR DESCRIPTION
http://www.sitepoint.com/unraveling-string-key-performance-ruby-2-2/
https://github.com/rack/rack/pull/737

```ruby
module V1
  module App
    class Ping < Grape::API
      format :json
      get '/ping' do
        present :ping, :pong
      end
    end
  end
end
```

```ruby
require 'rails_helper'
require 'memory_profiler'

describe ::API::API do
  describe "GET /v1/api/app/ping.json" do
    it "return 200" do
      report = MemoryProfiler.report do
        get "/v1/api/app/ping.json"
      end

      report.pretty_print
      expect(response.status).to eq(200)
    end
  end
end
```
before:
```grape_upstream/lib x 10369233```

after:
```grape/lib x 10366633```

```(10369233 - 10366633)/10369233.to_f * 100  #=> 0.02507417858196455```% fewer objects per request.

Maybe there are some missed optimizations.I will updated later.