### PR TITLE
Remove Ruby 1.9.3 from travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 rvm:
   - 2.1
   - 2.0.0
-  - 1.9.3
   - rbx-2.2.10
   - jruby-19mode
   - ruby-head


### PR DESCRIPTION
Support for Ruby 1.9.3 is officially over and security patches will not be backdated. It might be worth removing it from the travis build matrix.
https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended/