### PR TITLE
Use allow_message_expectations_on_nil to disable warnings

### DIFF
--- a/spec/grape/dsl/parameters_spec.rb
+++ b/spec/grape/dsl/parameters_spec.rb
@@ -43,7 +43,10 @@ module Grape
       subject { ParametersSpec::Dummy.new }
 
       describe '#use' do
-        before { allow(subject.api).to receive(:namespace_stackable).with(:named_params) }
+        before {
+          allow_message_expectations_on_nil
+          allow(subject.api).to receive(:namespace_stackable).with(:named_params)
+        }
         let(:options) { { option: 'value' } }
         let(:named_params) { { params_group: proc {} } }
 


### PR DESCRIPTION
```
Grape::DSL::Parameters
  #use
An expectation of :namespace_stackable was set on nil. Called from /Users/u2/grape/spec/grape/dsl/parameters_spec.rb:49:in `block (3 levels) in <module:DSL>'. Use allow_message_expectations_on_nil to disable warnings.
    calls processes associated with named params
An expectation of :namespace_stackable was set on nil. Called from /Users/u2/grape/spec/grape/dsl/parameters_spec.rb:49:in `block (3 levels) in <module:DSL>'. Use allow_message_expectations_on_nil to disable warnings.
    raises error when non-existent named param is called
```