### PR TITLE
Replaced map..flatten with flat_map

### DIFF
--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -53,7 +53,7 @@ module Grape
       protected
 
       def prepare_routes
-        endpoints.map(&:routes).flatten
+        endpoints.flat_map(&:routes)
       end
 
       # Execute first the provided block, then each of the

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -87,7 +87,7 @@ module Grape
     end
 
     def routes
-      @routes ||= endpoints ? endpoints.collect(&:routes).flatten : prepare_routes
+      @routes ||= endpoints ? endpoints.flat_map(&:routes) : prepare_routes
     end
 
     def reset_routes!


### PR DESCRIPTION
In these use cases, `flat_map` is more concise and performant