### PR TITLE
Implement named route helpers

### DIFF
--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -7,7 +7,9 @@ require 'rack/auth/basic'
 require 'rack/auth/digest/md5'
 require 'hashie'
 require 'set'
+require 'active_support'
 require 'active_support/version'
+require 'active_support/core_ext/class'
 require 'active_support/core_ext/hash/indifferent_access'
 
 if ActiveSupport::VERSION::MAJOR >= 4
@@ -37,6 +39,7 @@ module Grape
     autoload :API
     autoload :Endpoint
 
+    autoload :NamedRouteMatcher
     autoload :Route
     autoload :Namespace
 

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -50,11 +50,15 @@ module Grape
         end
       end
 
-      protected
+      def all_routes
+        subclasses.flat_map(&:prepare_routes)
+      end
 
       def prepare_routes
         endpoints.map(&:routes).flatten
       end
+
+      protected
 
       # Execute first the provided block, then each of the
       # block passed in. Allows for simple 'before' setups

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -10,6 +10,7 @@ module Grape
     attr_reader :env, :request, :headers, :params
 
     include Grape::DSL::InsideRoute
+    include Grape::NamedRouteMatcher
 
     class << self
       def before_each(new_setup = false, &block)

--- a/lib/grape/named_route_matcher.rb
+++ b/lib/grape/named_route_matcher.rb
@@ -1,0 +1,25 @@
+module Grape
+  module NamedRouteMatcher
+    def method_missing(method_id, *arguments)
+      segments = arguments.first || {}
+
+      route = Grape::API.all_routes.detect do |r|
+        route_match?(r, method_id, segments)
+      end
+
+      if route
+        route.send(method_id, *arguments)
+      else
+        super
+      end
+    end
+
+    def route_match?(route, method_name, segments)
+      return false unless route.respond_to?(method_name)
+      fail ArgumentError,
+           'Helper options must be a hash' unless segments.is_a?(Hash)
+      requested_segments = segments.keys.map(&:to_s)
+      route.uses_segments_in_path_helper?(requested_segments)
+    end
+  end
+end

--- a/lib/grape/route.rb
+++ b/lib/grape/route.rb
@@ -1,8 +1,114 @@
 module Grape
   # A compiled route for inspection.
   class Route
+    attr_reader :helper_names, :helper_arguments
+
     def initialize(options = {})
       @options = options || {}
+      @helper_names = []
+      @helper_arguments = required_helper_segments
+      define_path_helpers
+    end
+
+    def define_path_helpers
+      route_versions.each do |version|
+        opts = { version: version }
+        method_name = path_helper_name(opts)
+        @helper_names << method_name
+        define_path_helper(method_name, opts)
+      end
+    end
+
+    def define_path_helper(method_name, predefined_opts)
+      method_body = <<-RUBY
+        def #{method_name}(opts = {})
+          opts = #{predefined_opts}.merge(opts)
+          opts = HashWithIndifferentAccess.new(opts)
+
+          content_type = opts.delete(:format)
+          path = '/' + path_segments_with_values(opts).join('/')
+          extension = content_type ? '.' + content_type : ''
+
+          path + extension
+        end
+      RUBY
+      instance_eval method_body
+    end
+
+    def route_versions
+      if route_version
+        route_version.split('|')
+      else
+        [nil]
+      end
+    end
+
+    def path_helper_name(opts = {})
+      segments = path_segments_with_values(opts)
+
+      name = if segments.empty?
+               'root'
+             else
+               segments.join('_')
+             end
+      name + '_path'
+    end
+
+    def segment_to_value(segment, opts = {})
+      updated_options = @options.merge(opts)
+      options = HashWithIndifferentAccess.new(updated_options)
+
+      if dynamic_segment?(segment)
+        key = segment.slice(1..-1)
+        options[key]
+      else
+        segment
+      end
+    end
+
+    def path_segments_with_values(opts)
+      segments = path_segments.map { |s| segment_to_value(s, opts) }
+      segments.reject(&:blank?)
+    end
+
+    def path_segments
+      pattern = /\(\/?\.:format\)|\/|\*/
+      route_path.split(pattern).reject(&:blank?)
+    end
+
+    def dynamic_path_segments
+      segments = path_segments.select do |segment|
+        dynamic_segment?(segment)
+      end
+      segments.map { |s| s.slice(1..-1) }
+    end
+
+    def dynamic_segment?(segment)
+      segment.start_with?(':')
+    end
+
+    def required_helper_segments
+      segments_in_options = dynamic_path_segments.select do |segment|
+        @options[segment.to_sym]
+      end
+      dynamic_path_segments - segments_in_options
+    end
+
+    def optional_segments
+      ['format']
+    end
+
+    def uses_segments_in_path_helper?(segments)
+      requested = segments - optional_segments
+      required = required_helper_segments
+
+      if requested.empty? && required.empty?
+        true
+      else
+        requested.all? do |segment|
+          required.include?(segment)
+        end
+      end
     end
 
     def method_missing(method_id, *arguments)

--- a/spec/grape/named_route_matcher_spec.rb
+++ b/spec/grape/named_route_matcher_spec.rb
@@ -1,0 +1,163 @@
+require 'spec_helper'
+
+describe Grape::NamedRouteMatcher do
+  include described_class
+
+  let(:api) { Spec::Support::RouteMatcherHelpers.api }
+
+  let(:routes) do
+    api.routes
+  end
+
+  let(:ping_route) do
+    routes.detect do |route|
+      route.route_path =~ /ping/
+    end
+  end
+
+  let(:index_route) do
+    routes.detect do |route|
+      route.route_namespace =~ /cats$/
+    end
+  end
+
+  let(:show_route) do
+    routes.detect do |route|
+      route.route_namespace =~ /cats\/:id/
+    end
+  end
+
+  describe '#route_match?' do
+    context 'when route responds to a method name' do
+      let(:route) { ping_route }
+      let(:method_name) { :api_v1_ping_path }
+      let(:segments) { {} }
+
+      context 'when segments is not a hash' do
+        it 'raises an ArgumentError' do
+          expect do
+            route_match?(route, method_name, 1234)
+          end.to raise_error(ArgumentError)
+        end
+      end
+
+      it 'returns true' do
+        is_match = route_match?(route, method_name, segments)
+        expect(is_match).to eq(true)
+      end
+
+      context 'when requested segments contains expected options' do
+        let(:segments) { { 'format' => 'xml' } }
+
+        it 'returns true' do
+          is_match = route_match?(route, method_name, segments)
+          expect(is_match).to eq(true)
+        end
+
+        context 'when no dynamic segments are requested' do
+          context 'when the route requires dynamic segments' do
+            let(:route) { show_route }
+            let(:method_name) { :ap1_v1_cats_path }
+
+            it 'returns false' do
+              is_match = route_match?(route, method_name, segments)
+              expect(is_match).to eq(false)
+            end
+          end
+
+          context 'when the route does not require dynamic segments' do
+            it 'returns true' do
+              is_match = route_match?(route, method_name, segments)
+              expect(is_match).to eq(true)
+            end
+          end
+        end
+
+        context 'when route requires the requested segments' do
+          let(:route) { show_route }
+          let(:method_name) { :api_v1_cats_path }
+          let(:segments) { { id: 1 } }
+
+          it 'returns true' do
+            is_match = route_match?(route, method_name, segments)
+            expect(is_match).to eq(true)
+          end
+        end
+
+        context 'when route does not require the requested segments' do
+          let(:segments) { { some_option: 'some value' } }
+
+          it 'returns false' do
+            is_match = route_match?(route, method_name, segments)
+            expect(is_match).to eq(false)
+          end
+        end
+      end
+
+      context 'when segments contains unexpected options' do
+        let(:segments) { { some_option: 'some value' } }
+
+        it 'returns false' do
+          is_match = route_match?(route, method_name, segments)
+          expect(is_match).to eq(false)
+        end
+      end
+    end
+
+    context 'when route does not respond to a method name' do
+      let(:method_name) { :some_other_path }
+      let(:route) { ping_route }
+      let(:segments) { {} }
+
+      it 'returns false' do
+        is_match = route_match?(route, method_name, segments)
+        expect(is_match).to eq(false)
+      end
+    end
+  end
+
+  describe '#method_missing' do
+    context 'when method name matches a Grape::Route path helper name' do
+      it 'returns the path for that route object' do
+        api
+
+        path = api_v1_ping_path
+        expect(path).to eq('/api/v1/ping')
+      end
+
+      context 'when argument to the helper is not a hash' do
+        it 'raises an ArgumentError' do
+          api
+
+          expect do
+            api_v1_ping_path(1234)
+          end.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    context 'when method name does not match a Grape::Route path helper name' do
+      it 'raises a NameError' do
+        api
+
+        expect do
+          some_method_name
+        end.to raise_error(NameError)
+      end
+    end
+  end
+
+  context 'when Grape::Route objects share the same helper name' do
+    context 'when helpers require different segments to generate their path' do
+      it 'uses arguments to infer which route to use' do
+        api
+
+        show_path = api_v1_cats_path('id' => 1)
+        expect(show_path).to eq('/api/v1/cats/1')
+
+        index_path = api_v1_cats_path
+        expect(index_path).to eq('/api/v1/cats')
+      end
+    end
+  end
+end

--- a/spec/grape/route_spec.rb
+++ b/spec/grape/route_spec.rb
@@ -1,0 +1,166 @@
+require 'spec_helper'
+
+describe Grape::Route do
+  let(:api) { Spec::Support::RouteMatcherHelpers.api }
+
+  let(:routes) do
+    api.routes
+  end
+
+  let(:index_route) do
+    routes.detect { |route| route.route_namespace == '/cats' }
+  end
+
+  let(:show_route) do
+    routes.detect { |route| route.route_namespace == '/cats/:id' }
+  end
+
+  let(:catch_all_route) do
+    routes.detect { |route| route.route_path =~ /\*/ }
+  end
+
+  describe '#helper_names' do
+    context 'when an API has multiple versions' do
+      let(:api_versions) { %w(beta alpha v1) }
+
+      before do
+        api.version api_versions
+      end
+
+      it "returns the route's helper name for each version" do
+        helper_names = show_route.helper_names
+        expect(helper_names.size).to eq(api_versions.size)
+      end
+    end
+
+    context 'when an API has one version' do
+      it "returns the route's helper name for that version" do
+        helper_name = show_route.helper_names.first
+        expect(helper_name).to eq('api_v1_cats_path')
+      end
+    end
+  end
+
+  describe '#helper_arguments' do
+    context 'when no user input is needed to generate the correct path' do
+      it 'returns an empty array' do
+        expect(index_route.helper_arguments).to eq([])
+      end
+    end
+
+    context 'when user input is needed to generate the correct path' do
+      it 'returns an array of required segments' do
+        expect(show_route.helper_arguments).to eq(['id'])
+      end
+    end
+  end
+
+  describe '#path_segments_with_values' do
+    context 'when path has dynamic segments' do
+      it 'replaces segments with corresponding values found in @options' do
+        opts = { id: 1 }
+        result = show_route.path_segments_with_values(opts)
+        expect(result).to include(1)
+      end
+
+      context 'when options contains string keys' do
+        it 'replaces segments with corresponding values found in the options' do
+          opts = { 'id' => 1 }
+          result = show_route.path_segments_with_values(opts)
+          expect(result).to include(1)
+        end
+      end
+    end
+  end
+
+  describe '#path_helper_name' do
+    it "returns the name of a route's helper method" do
+      expect(index_route.path_helper_name).to eq('api_v1_cats_path')
+    end
+
+    context 'when the path is the root path' do
+      let(:api_with_root) do
+        Class.new(Grape::API) do
+          get '/' do
+          end
+        end
+      end
+
+      let(:root_route) do
+        api_with_root.routes.first
+      end
+
+      it 'returns "root_path"' do
+        result = root_route.path_helper_name
+        expect(result).to eq('root_path')
+      end
+    end
+
+    context 'when the path is a catch-all path' do
+      it 'returns a name without the glob star' do
+        result = catch_all_route.path_helper_name
+        expect(result).to eq('api_v1_path_path')
+      end
+    end
+  end
+
+  describe '#segment_to_value' do
+    context 'when segment is dynamic' do
+      it 'returns the value the segment corresponds to' do
+        result = index_route.segment_to_value(':version')
+        expect(result).to eq('v1')
+      end
+
+      context 'when segment is found in options' do
+        it 'returns the value found in options' do
+          options = { id: 1 }
+          result = show_route.segment_to_value(':id', options)
+          expect(result).to eq(1)
+        end
+      end
+    end
+
+    context 'when segment is static' do
+      it 'returns the segment' do
+        result = index_route.segment_to_value('api')
+        expect(result).to eq('api')
+      end
+    end
+  end
+
+  describe 'path helper method' do
+    context 'when helper does not require arguments' do
+      it 'returns the correct path' do
+        path = index_route.api_v1_cats_path
+        expect(path).to eq('/api/v1/cats')
+      end
+    end
+
+    context 'when arguments are needed required to construct the right path' do
+      context 'when not missing arguments' do
+        it 'returns the correct path' do
+          path = show_route.api_v1_cats_path(id: 1)
+          expect(path).to eq('/api/v1/cats/1')
+        end
+      end
+    end
+
+    context "when a route's API has multiple versions" do
+      before(:each) do
+        api.version %w(v1 v2)
+      end
+
+      it 'returns a path for each version' do
+        expect(index_route.api_v1_cats_path).to eq('/api/v1/cats')
+        expect(index_route.api_v2_cats_path).to eq('/api/v2/cats')
+      end
+    end
+
+    context 'when a format is given' do
+      it 'returns the path with a correct extension' do
+        path = show_route.api_v1_cats_path(id: 1, format: 'xml')
+        expect(path).to eq('/api/v1/cats/1.xml')
+      end
+    end
+  end
+end

--- a/spec/support/route_matcher_helpers.rb
+++ b/spec/support/route_matcher_helpers.rb
@@ -1,0 +1,33 @@
+module Spec
+  module Support
+    module RouteMatcherHelpers
+      def self.api
+        Class.new(Grape::API) do
+          version 'v1'
+          prefix 'api'
+          format 'json'
+
+          get 'ping' do
+            'pong'
+          end
+
+          resource :cats do
+            get '/' do
+              %w(cats cats cats)
+            end
+
+            route_param :id do
+              get do
+                'cat'
+              end
+            end
+          end
+
+          route :any, '*path' do
+            'catch-all route'
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi,

This is a response to issue #863; it adds path helper functions to Grape projects. I also have a [fork of grape-on-rack](https://github.com/reprah/grape-on-rack/tree/named-route-helpers#get-redirected-grape-route-helpers-demonstration) to demonstrate it (there are new instructions in its README). If there's anything I can provide to make it more obvious how the feature works, or if I need to explain why I did something a certain way, please let me know.

Summary: Grape::Route objects have dynamically named methods that return their paths, and there's a module called NamedRouteMatcher that does nothing but use its `method_missing` to match a method name to those routes and returns a path. The module's included in Grape::Endpoint and can be included by itself into another project.

I tried to provide thorough test coverage, and all new files have been Rubocop'd.

I'd like your thoughts on two things in particular:

- The difference between including the route helpers module at the Grape::Endpoint class level vs. [extending the individual Grape::Endpoint instances](https://github.com/intridea/grape/blob/master/lib/grape/endpoint.rb#L188)
- When it's appropriate to make something a private method in this project

Thanks for any feedback.