### PR TITLE
mention grape_logging in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1589,6 +1589,8 @@ class API < Grape::API
 end
 ```
 
+For similar to Rails request logging try the [grape_logging](https://github.com/aserafin/grape_logging) gem.
+
 ## API Formats
 
 Your API can declare which content-types to support by using `content_type`. If you do not specify any, Grape will support


### PR DESCRIPTION
Adding request logging with parameters, error codes etc was always the first thing after starting new grape project for me so I though I would make a gem out of it and make it easier for the other developers.   Putting it in the readme would help spread the word!

[grape_logging](https://github.com/aserafin/grape_logging)