### PR TITLE
Added support for coercion to Set or Set[Other]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 #### Features
 
+* [#995](https://github.com/intridea/grape/issues/995): Added support for coercion to Set or Set[Other] - [@jordansexton](https://github.com/jordansexton) [@u2](https://github.com/u2).
 * [#980](https://github.com/intridea/grape/issues/980): Grape is now eager-loaded - [@u2](https://github.com/u2).
 * [#956](https://github.com/intridea/grape/issues/956): Support `present` with `Grape::Presenters::Presenter`  - [@u2](https://github.com/u2).
 * [#974](https://github.com/intridea/grape/pull/974): Added `error!` to `rescue_from` blocks - [@whatasunnyday](https://github.com/whatasunnyday).

--- a/lib/grape/validations/validators/coerce.rb
+++ b/lib/grape/validations/validators/coerce.rb
@@ -41,8 +41,8 @@ module Grape
       end
 
       def valid_type?(val)
-        if @option.is_a?(Array)
-          _valid_array_type?(@option[0], val)
+        if @option.is_a?(Array) || @option.is_a?(Set)
+          _valid_array_type?(@option.first, val)
         else
           _valid_single_type?(@option, val)
         end
@@ -50,8 +50,9 @@ module Grape
 
       def coerce_value(type, val)
         # Don't coerce things other than nil to Arrays or Hashes
-        return val || [] if type == Array
-        return val || {} if type == Hash
+        return val || []      if type == Array
+        return val || Set.new if type == Set
+        return val || {}      if type == Hash
 
         converter = Virtus::Attribute.build(type)
         converter.coerce(val)

--- a/spec/grape/validations/validators/coerce_spec.rb
+++ b/spec/grape/validations/validators/coerce_spec.rb
@@ -122,30 +122,60 @@ describe Grape::Validations::CoerceValidator do
         expect(last_response.body).to eq('Fixnum')
       end
 
-      it 'Array of Integers' do
-        subject.params do
-          requires :arry, coerce: Array[Integer]
-        end
-        subject.get '/array' do
-          params[:arry][0].class
+      context 'Array' do
+        it 'Array of Integers' do
+          subject.params do
+            requires :arry, coerce: Array[Integer]
+          end
+          subject.get '/array' do
+            params[:arry][0].class
+          end
+
+          get '/array', arry: %w(1 2 3)
+          expect(last_response.status).to eq(200)
+          expect(last_response.body).to eq('Fixnum')
         end
 
-        get '/array', arry: %w(1 2 3)
-        expect(last_response.status).to eq(200)
-        expect(last_response.body).to eq('Fixnum')
+        it 'Array of Bools' do
+          subject.params do
+            requires :arry, coerce: Array[Virtus::Attribute::Boolean]
+          end
+          subject.get '/array' do
+            params[:arry][0].class
+          end
+
+          get 'array', arry: [1, 0]
+          expect(last_response.status).to eq(200)
+          expect(last_response.body).to eq('TrueClass')
+        end
       end
 
-      it 'Array of Bools' do
-        subject.params do
-          requires :arry, coerce: Array[Virtus::Attribute::Boolean]
-        end
-        subject.get '/array' do
-          params[:arry][0].class
+      context 'Set' do
+        it 'Set of Integers' do
+          subject.params do
+            requires :set, coerce: Set[Integer]
+          end
+          subject.get '/set' do
+            params[:set].first.class
+          end
+
+          get '/set', set: Set.new([1, 2, 3, 4]).to_a
+          expect(last_response.status).to eq(200)
+          expect(last_response.body).to eq('Fixnum')
         end
 
-        get 'array', arry: [1, 0]
-        expect(last_response.status).to eq(200)
-        expect(last_response.body).to eq('TrueClass')
+        it 'Set of Bools' do
+          subject.params do
+            requires :set, coerce: Set[Virtus::Attribute::Boolean]
+          end
+          subject.get '/set' do
+            params[:set].first.class
+          end
+
+          get '/set', set: Set.new([1, 0]).to_a
+          expect(last_response.status).to eq(200)
+          expect(last_response.body).to eq('TrueClass')
+        end
       end
 
       it 'Bool' do


### PR DESCRIPTION
> I like Virtus's support for coercion to Sets as seen here:
https://github.com/solnic/virtus#collection-member-coercions

> They can be treated the same as Arrays in the case of `nil`, and changing line 41 from `@option[0]` to `@option.first` behaves the same for either.