### PR TITLE
allow_blank boolean fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * [#942](https://github.com/intridea/grape/pull/942): Fixed forced presence for optional params when based on a reused entity that was also required in another context - [@croeck](https://github.com/croeck).
 * [#1001](https://github.com/intridea/grape/pull/1001): Fixed calling endpoint with specified format with format in its path - [@hodak](https://github.com/hodak).
 * [#1005](https://github.com/intridea/grape/pull/1005): Fixed the Grape::Middleware::Globals - [@urkle](https://github.com/urkle).
-
+* [#1012](https://github.com/intridea/grape/pull/1012): Fixed `allow_blank: false` with a Boolean value of `false` - [@mfunaro](https://github.com/mfunaro).
 * Your contribution here.
 
 0.11.0 (2/23/2015)

--- a/lib/grape/validations/validators/allow_blank.rb
+++ b/lib/grape/validations/validators/allow_blank.rb
@@ -21,7 +21,7 @@ module Grape
 
         return unless should_validate
 
-        unless value.present?
+        unless value == false || value.present?
           fail Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message_key: :blank
         end
       end

--- a/spec/grape/validations/validators/allow_blank_spec.rb
+++ b/spec/grape/validations/validators/allow_blank_spec.rb
@@ -67,6 +67,11 @@ describe Grape::Validations::AllowBlankValidator do
         get '/allow_boolean_blank'
 
         params do
+          requires :val, type: Boolean, allow_blank: false
+        end
+        get '/disallow_boolean_blank'
+
+        params do
           optional :user, type: Hash do
             requires :name, allow_blank: false
           end
@@ -199,6 +204,11 @@ describe Grape::Validations::AllowBlankValidator do
 
     it 'accepts empty when boolean allow_blank' do
       get '/allow_boolean_blank', val: ''
+      expect(last_response.status).to eq(200)
+    end
+
+    it 'accepts false when boolean allow_blank' do
+      get '/disallow_boolean_blank', val: false
       expect(last_response.status).to eq(200)
     end
   end


### PR DESCRIPTION
Fix allow_blank validator such that validation will not fail when a value of false is sent in a boolean param and allow_blank is set to false.