### PR TITLE
Update readme to include content type in case content type validation…

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ Multipart POSTs and PUTs are supported as well.
 The request:
 
 ```
-curl --form image_file=@image.jpg http://localhost:9292/upload
+curl --form image_file='@image.jpg;type=image/jpg' http://localhost:9292/upload
 ```
 
 The Grape endpoint:


### PR DESCRIPTION
If you try to upload a file with the current curl statement, chances are you'll get an error since the latest grape encourages you to enable validation, and one would assume that most will use content type validation.