### PR TITLE
Fixed validation of invalid params with mutual_exclusive inside hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#1005](https://github.com/intridea/grape/pull/1005): Fixed the Grape::Middleware::Globals - [@urkle](https://github.com/urkle).
 * [#1012](https://github.com/intridea/grape/pull/1012): Fixed `allow_blank: false` with a Boolean value of `false` - [@mfunaro](https://github.com/mfunaro).
 * [#1023](https://github.com/intridea/grape/issues/1023): Fixes unexpected beahvior with `present` and an object that responds to `merge` but isn't a Hash - [@dblock](https://github.com/dblock).
+* [#1017](https://github.com/intridea/grape/pull/1017): Fixed `undefined method stringify_keys` with nested mutual exclusive params - [@quickpay](https://github.com/quickpay).
 * Your contribution here.
 
 0.11.0 (2/23/2015)

--- a/lib/grape/validations/validators/multiple_params_base.rb
+++ b/lib/grape/validations/validators/multiple_params_base.rb
@@ -15,6 +15,7 @@ module Grape
       end
 
       def keys_in_common(resource_params)
+        return [] unless resource_params.is_a?(Hash)
         (all_keys & resource_params.stringify_keys.keys).map(&:to_s)
       end
 

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -1132,6 +1132,25 @@ describe Grape::Validations do
           expect(last_response.status).to eq(400)
         end
       end
+
+      context 'mutually exclusive params inside Hash group' do
+        it 'invalidates if request param is invalid type' do
+          subject.params do
+            optional :wine, type: Hash do
+              optional :grape
+              optional :country
+              mutually_exclusive :grape, :country
+            end
+          end
+          subject.post '/mutually_exclusive' do
+            'mutually_exclusive works!'
+          end
+
+          post '/mutually_exclusive', wine: '2015 sauvignon'
+          expect(last_response.status).to eq(400)
+          expect(last_response.body).to eq 'wine is invalid'
+        end
+      end
     end
 
     context 'exactly one of' do


### PR DESCRIPTION
This fixes an issue with `mutual_exclusive` params inside a `type: Hash` param.

With these params:

```ruby
params do
  optional :wine, type: Hash do
    optional :grape
    optional :country
    mutually_exclusive :grape, :country
  end
end
```

And the request params `{ wine: "This is a string, not a hash" }`

I'd expect an error message, but instead get an unhandled error:

    undefined method `stringify_keys' for "This is a string, not a hash":String