### PR TITLE
Only dup StackableValues

### DIFF
--- a/lib/grape/util/stackable_values.rb
+++ b/lib/grape/util/stackable_values.rb
@@ -45,7 +45,7 @@ module Grape
       def initialize_copy(other)
         super
         self.inherited_values = other.inherited_values
-        self.new_values = other.new_values.deep_dup
+        self.new_values = other.new_values.dup
       end
     end
   end

--- a/spec/grape/util/stackable_values_spec.rb
+++ b/spec/grape/util/stackable_values_spec.rb
@@ -109,6 +109,16 @@ module Grape
 
           expect(grandchild.clone.to_hash).to eq(some_thing: [:foo, [:bar, :more], :grand_foo_bar], some_thing_more: [:foo_bar])
         end
+
+        context 'complex (i.e. not primitive) data types (ex. middleware, please see bug #930)' do
+          let(:middleware) { double }
+
+          before { subject[:middleware] = middleware }
+
+          it 'copies values; does not duplicate them' do
+            expect(obj_cloned[:middleware]).to eq [middleware]
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

To fix #930, settings managed with `StackableValues` (including custom middleware) are now `dup`ed instead of `deep_dup`ed when `mount` is used.

## Impact

Although it's a small change in terms of character count, the impact seems large. One category of affected code appears to be "custom middleware that maintains global state" like [Warden's test hook system](https://github.com/hassox/warden/blob/master/lib/warden/test/warden_helpers.rb), but there may be many others.

Please note that to reduce the impact, _only_ `StackableValues` has been modified. `InheritableValues`, which also persists settings, still uses `deep_dup`.  If this inconsistency is confusing or otherwise undesirable, I'm happy to drop `deep_dup` usage (and support) entirely. Regardless, I'm hoping the authors of #739 can weigh in with any suggestions!

## Background

Here are the events that led to me to this change:

  * [My original bug report](https://github.com/intridea/grape/pull/930) about Warden's `login_as` test helper, where I guess `deep_dup`ing is responsible
  * A [deep dive](https://github.com/intridea/grape/pull/930#issuecomment-76635077) into the effects of `deep_dup` on Warden
  * [@dblock suggests](https://github.com/intridea/grape/pull/930#issuecomment-76754338) we develop a white-list for settings that _need_ to be `deep_dup`ed
  * However, [the tests suggest](https://github.com/intridea/grape/commit/009be00e4f6d149072ef065abeea6c3bc845ea43) that _no_ settings need to be `deep_dup`ed

## Testing

  * I've added a test case to `stackable_values_spec.rb` that closely resembles the root cause of #930
  * I've also confirmed that the bug is fixed in my real Grape project

Beyond this, perhaps we could have a few volunteers that:

  * have complex configurations and/or
  * use a lot of custom middleware
 
&hellip;try this change in real projects?

## Related Issues

  * #739: when `deep_dup`ing settings was introduced, later released in [v0.10.0](https://github.com/intridea/grape/releases/tag/v0.10.0)
  * #930: my original bug report about Warden's `login_as` test helper
  * #891: another reference to negative effects of `deep_dup`ing