### PR TITLE
Don't try to dup the String class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 Next Release
 ============
 
-* Your contribution here.
+#### Features
+
+#### Fixes
+* [#1038](https://github.com/intridea/grape/pull/1038): Avoid dup-ing the String class when used in inherited params - [@rnubel](https://github.com/rnubel).
 
 0.12.0 (6/18/2015)
 ==================

--- a/lib/backports/active_support/duplicable.rb
+++ b/lib/backports/active_support/duplicable.rb
@@ -73,6 +73,15 @@ class Numeric
     false
   end
 end
+class String
+  class << self
+    # Rubinius explicitly disallows this. Also, there's no real
+    # reason you'd want to duplicate the String class in a deep_dup.
+    def duplicable?
+      false
+    end
+  end
+end
 require 'bigdecimal'
 # rubocop:disable Lint/HandleExceptions
 class BigDecimal

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -15,6 +15,7 @@ if ActiveSupport::VERSION::MAJOR >= 4
 else
   require_relative 'backports/active_support/deep_dup'
 end
+require_relative 'backports/active_support/duplicable'
 
 require 'active_support/ordered_hash'
 require 'active_support/core_ext/object/conversions'

--- a/spec/grape/util/inheritable_values_spec.rb
+++ b/spec/grape/util/inheritable_values_spec.rb
@@ -58,6 +58,13 @@ module Grape
           expect(subject.to_hash).to eq(some_thing: :foo, some_thing_more: :foo_bar)
         end
       end
+
+      describe '#clone' do
+        it 'clones itself even when containing a String class' do
+          subject[:foo] = String
+          expect(subject.clone.to_hash).to eq(foo: String)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This addresses #873 by preventing ActiveSupport#deep_dup from trying to duplicate the String class (note: I mean strictly the String class, not String instances). However, there are a few points to consider:

* Is this change worth making? The issue likely doesn't affect too many people, but the fix would apply to everyone.
* If yes to the above, should it be pushed up to ActiveSupport and/or left as a monkey-patch in Grape?
* Are there other classes in Rubinius with landmines like [this one](https://github.com/rubinius/rubinius/blame/60cfdadf0149ca0efebf2b924a0482e4cfa1b404/kernel/common/string.rb#L39)?