### PR TITLE
Add support for named routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 - [Current Route and Endpoint](#current-route-and-endpoint)
 - [Before and After](#before-and-after)
 - [Anchoring](#anchoring)
+- [Named Routes](#named-routes)
 - [Using Custom Middleware](#using-custom-middleware)
   - [Rails Middleware](#rails-middleware)
     - [Remote IP](#remote-ip)
@@ -2301,6 +2302,48 @@ Luckily this can be circumvented by using the described above syntax for path
 specification and using the `PATH_INFO` Rack environment variable, using
 `env["PATH_INFO"]`. This will hold everything that comes after the '/statuses/'
 part.
+
+# Named Routes
+
+You can set a name to a route to call it later without hardcoding it's path:
+
+```ruby
+module Twitter
+  class API < Grape::API
+    version 'v1', using: :header, vendor: 'twitter'
+    format :json
+    prefix :api
+
+    resource :statuses do
+      desc 'Route without params.'
+      get :home_timeline, as: :home_timeline do
+        Twitter::API.get_named_path(:home_timeline)
+      end
+
+      desc 'Route with route_param.'
+      params do
+        requires :id, type: Integer
+      end
+      route_param :id do
+        get as: :status do
+          Twitter::API.get_named_path(:status, id: params[:id])
+        end
+      end
+
+      desc 'Route with inline param'
+      params do
+        requires :inline, type: String
+      end
+      get '/custom_route/:inline', as: :inline do
+        Twitter::API.get_named_path(:inline, inline: params[:inline])
+      end
+    end
+
+  end
+end
+```
+
+These three endpoints simply return their URL.
 
 # Using Custom Middleware
 

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -123,6 +123,15 @@ module Grape
     end
   end
 
+  module NamedRoutes
+    extend ActiveSupport::Autoload
+    autoload :NamedRouteNotFound
+    autoload :NamedRouteSeeker
+    autoload :PathCompiler
+    autoload :MissedRequiredParam
+    autoload :NamedPathHelper
+  end
+
   module Util
     extend ActiveSupport::Autoload
     autoload :InheritableValues

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -4,6 +4,7 @@ module Grape
   # class in order to build an API.
   class API
     include Grape::DSL::API
+    extend NamedRoutes::NamedPathHelper
 
     class << self
       attr_reader :instance
@@ -13,6 +14,7 @@ module Grape
         @route_set = Rack::Mount::RouteSet.new
         @endpoints = []
         @routes = nil
+        @named_route_seeker = nil
         reset_validations!
       end
 

--- a/lib/grape/named_routes/missed_required_param.rb
+++ b/lib/grape/named_routes/missed_required_param.rb
@@ -1,0 +1,11 @@
+module Grape
+  module NamedRoutes
+    class MissedRequiredParam < StandardError
+      attr_reader :missed_param
+
+      def initialize(param)
+        @missed_param = param
+      end
+    end
+  end
+end

--- a/lib/grape/named_routes/named_path_helper.rb
+++ b/lib/grape/named_routes/named_path_helper.rb
@@ -1,0 +1,27 @@
+module Grape
+  module NamedRoutes
+    module NamedPathHelper
+      def get_named_path(route_name, route_params = {})
+        endpoint = named_route_seeker.find_endpoint!(route_name)
+        NamedRoutes::PathCompiler.compile_path(endpoint.routes.first, route_params)
+      end
+
+      def named_route_seeker
+        @named_route_seeker ||= NamedRoutes::NamedRouteSeeker.new(self)
+      end
+
+      def method_missing(method, *arguments)
+        if method =~ /\w+_path/
+          route_name = method.to_s.sub(/_path$/, '')
+          endpoint = named_route_seeker.find_endpoint(route_name)
+        end
+
+        if endpoint
+          NamedRoutes::PathCompiler.compile_path(endpoint.routes.first, arguments.first || {})
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/grape/named_routes/named_route_not_found.rb
+++ b/lib/grape/named_routes/named_route_not_found.rb
@@ -1,0 +1,11 @@
+module Grape
+  module NamedRoutes
+    class NamedRouteNotFound < StandardError
+      attr_reader :missed_route
+
+      def initialize(route_name)
+        @missed_route = route_name
+      end
+    end
+  end
+end

--- a/lib/grape/named_routes/named_route_seeker.rb
+++ b/lib/grape/named_routes/named_route_seeker.rb
@@ -1,0 +1,38 @@
+module Grape
+  module NamedRoutes
+    class NamedRouteSeeker
+      def initialize(app)
+        @app = app
+      end
+
+      def find_endpoint(name)
+        name_to_endpoint_hash[name.to_sym]
+      end
+
+      def find_endpoint!(name)
+        fail NamedRouteNotFound.new(name), "Named route '#{name}' is missed." unless named_endpoint_present?(name)
+        find_endpoint(name)
+      end
+
+      private
+
+      def named_endpoint_present?(name)
+        name_to_endpoint_hash.key?(name.to_sym)
+      end
+
+      def named_endpoints
+        @named_endpoints ||= @app.endpoints.select do |endpoint|
+          endpoint.options[:route_options].key?(:as)
+        end
+      end
+
+      def name_to_endpoint_hash
+        @name_to_endpoint_hash ||= named_endpoints.inject({}) do |hash, endpoint|
+          endpoint_name = endpoint.options[:route_options][:as].to_sym
+          hash[endpoint_name] = endpoint
+          hash
+        end
+      end
+    end
+  end
+end

--- a/lib/grape/named_routes/path_compiler.rb
+++ b/lib/grape/named_routes/path_compiler.rb
@@ -1,0 +1,49 @@
+module Grape
+  module NamedRoutes
+    module PathCompiler
+      class << self
+        # this method substitutes given params to route path
+        def compile_path(route, params = {})
+          path_with_optional_params = substitute_optional_params(route.route_path, params)
+          substitute_required_params(path_with_optional_params, params)
+        end
+
+        private
+
+        def substitute_optional_params(path, params)
+          # explanation for regexp below: we seek parenthesis
+          # with string like :string in them (possibly appended and/or prepended with smth)
+          #
+          # for example, for string '/api/statuses/:id/(.:format)'
+          #   match[1] will be '.'
+          #   match[2] will be param_value(params, format)
+          #   match[3] will be nil
+          #
+          # It could be rewrote with $1,$2,$3, but Rubocop doesn't like these variables
+          optional_params_regexp = /\((.*):(\w+)(.*)\)/
+
+          path.gsub(optional_params_regexp) do
+            match = Regexp.last_match
+            value = param_value(params, match[2])
+            [match[1], value, match[3]].join if value
+          end
+        end
+
+        def substitute_required_params(path, params)
+          path.gsub(/:(\w+)/) do
+            param = Regexp.last_match[1]
+            value = param_value(params, param)
+            unless value
+              fail Grape::NamedRoutes::MissedRequiredParam.new(param), "Required param '#{param}' is missed."
+            end
+            value
+          end
+        end
+
+        def param_value(params, param)
+          params[param] || params[param.to_sym]
+        end
+      end
+    end
+  end
+end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -2904,4 +2904,54 @@ XML
       end
     end
   end
+
+  describe '.get_named_path' do
+    before do
+      subject.namespace :users do
+        route_param :id do
+          get as: :user do
+            params[:id]
+          end
+        end
+      end
+    end
+
+    it 'returns path with substituted params' do
+      expect(subject.get_named_path(:user, id: 1, format: 'json')).to eq('/users/1.json')
+    end
+
+    it 'raises Grape::NamedRoutes::NamedRouteNotFound when named_route is missed' do
+      expect {
+        subject.get_named_path(:wrong_route)
+      }.to raise_error(Grape::NamedRoutes::NamedRouteNotFound)
+    end
+
+    it 'raises Grape::NamedRoutes::MissedRequiredParam when required param is missed' do
+      expect {
+        subject.get_named_path(:user)
+      }.to raise_error(Grape::NamedRoutes::MissedRequiredParam)
+    end
+  end
+
+  describe 'dynamic _path methods' do
+    before do
+      subject.namespace :users do
+        route_param :id do
+          get as: :user do
+            params[:id]
+          end
+        end
+      end
+    end
+
+    it 'returns path with substituted params' do
+      expect(subject.user_path(id: 1, format: 'json')).to eq('/users/1.json')
+    end
+
+    it 'raises NoMethodError when named_route is missed' do
+      expect {
+        subject.wrong_route_path
+      }.to raise_error(NoMethodError)
+    end
+  end
 end


### PR DESCRIPTION
This PR implements support for named routes. It's related to #787 issue. I added possibility to access routes tagged with :as option and compile path from them via substituting parameters. Example:

```ruby
module Twitter
  class API < Grape::API
    prefix :api

    resource :statuses do
      desc 'Route with route_param.'
      params do
        requires :id, type: Integer
      end
      route_param :id do
        get as: :status do
          Twitter::API.get_named_path(:status, id: params[:id], format: 'json')
          # returns "/api/statuses/1.json" when params[:id] == '1'

          Twitter::API.get_named_path(:status, id: params[:id])
          # returns "/api/statuses/1" when params[:id] == '1'

          Twitter::API.get_named_path(:wrong_route, id: params[:id])
          # fails with Grape::NamedRoutes::NamedRouteNotFound

          Twitter::API.get_named_path(:status)
          # fails with Grape::NamedRoutes::MissedRequiredParam

        end
      end
    end
  end
end
```