### PR TITLE
Increase documentation coverage

### DIFF
--- a/lib/grape/dsl/callbacks.rb
+++ b/lib/grape/dsl/callbacks.rb
@@ -2,24 +2,44 @@ require 'active_support/concern'
 
 module Grape
   module DSL
+    # Blocks can be executed before or after every API call, using `before`, `after`,
+    # `before_validation` and `after_validation`.
+    #
+    # Before and after callbacks execute in the following order:
+    #
+    # 1. `before`
+    # 2. `before_validation`
+    # 3. _validations_
+    # 4. `after_validation`
+    # 5. _the API call_
+    # 6. `after`
+    #
+    # Steps 4, 5 and 6 only happen if validation succeeds.
     module Callbacks
       extend ActiveSupport::Concern
 
       include Grape::DSL::Configuration
 
       module ClassMethods
+        # Execute the given block before validation, coercion, or any endpoint
+        # code is executed.
         def before(&block)
           namespace_stackable(:befores, block)
         end
 
+        # Execute the given block after `before`, but prior to validation or
+        # coercion.
         def before_validation(&block)
           namespace_stackable(:before_validations, block)
         end
 
+        # Execute the given block after validations and coercions, but before
+        # any endpoint code.
         def after_validation(&block)
           namespace_stackable(:after_validations, block)
         end
 
+        # Execute the given block after the endpoint code has run.
         def after(&block)
           namespace_stackable(:afters, block)
         end

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -238,6 +238,14 @@ module Grape
         env['rack.routing_args'][:route_info]
       end
 
+      # Attempt to locate the Entity class for a given object, if not given
+      # explicitly. This is done by looking for the presence of Klass::Entity,
+      # where Klass is the class of the `object` parameter, or one of its
+      # ancestors.
+      # @param object [Object] the object to locate the Entity class for
+      # @param options [Hash]
+      # @option options :with [Class] the explicit entity class to use
+      # @return [Class] the located Entity class, or nil if none is found
       def entity_class_for_obj(object, options)
         entity_class = options.delete(:with)
 
@@ -259,6 +267,8 @@ module Grape
         entity_class
       end
 
+      # @return the representation of the given object as done through
+      #   the given entity_class.
       def entity_representation_for(entity_class, object, options)
         embeds = { env: env }
         embeds[:version] = env['api.version'] if env['api.version']

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -2,6 +2,9 @@ require 'active_support/concern'
 
 module Grape
   module DSL
+    # Defines DSL methods, meant to be applied to a ParamsScope, which define
+    # and describe the parameters accepted by an endpoint, or all endpoints
+    # within a namespace.
     module Parameters
       extend ActiveSupport::Concern
 
@@ -39,6 +42,47 @@ module Grape
       alias_method :use_scope, :use
       alias_method :includes, :use
 
+      # Require one or more parameters for the current endpoint.
+      #
+      # @param attrs list of parameter names, or, if :using is
+      #   passed as an option, which keys to include (:all or :none) from
+      #   the :using hash. The last key can be a hash, which specifies
+      #   options for the parameters
+      # @option attrs :type [Class] the type to coerce this parameter to before
+      #   passing it to the endpoint. See Grape::ParameterTypes for supported
+      #   types, or use a class that defines `::parse` as a custom type
+      # @option attrs :desc [String] description to document this parameter
+      # @option attrs :default [Object] default value, if parameter is optional
+      # @option attrs :values [Array] permissable values for this field. If any
+      #   other value is given, it will be handled as a validation error
+      # @option attrs :using [Hash[Symbol => Hash]] a hash defining keys and
+      #   options, like that returned by Grape::Entity#documentation. The value
+      #   of each key is an options hash accepting the same parameters
+      # @option attrs :except [Array[Symbol]] a list of keys to exclude from
+      #   the :using Hash. The meaning of this depends on if :all or :none was
+      #   passed; :all + :except will make the :except fields optional, whereas
+      #   :none + :except will make the :except fields required
+      #
+      # @example
+      #
+      #     params do
+      #       # Basic usage: require a parameter of a certain type
+      #       requires :user_id, type: Integer
+      #
+      #       # You don't need to specify type; String is default
+      #       requires :foo
+      #
+      #       # Multiple params can be specified at once if they share
+      #       # the same options.
+      #       requires :x, :y, :z, type: Date
+      #
+      #       # Nested parameters can be handled as hashes. You must
+      #       # pass in a block, within which you can use any of the
+      #       # parameters DSL methods.
+      #       requires :user, type: Hash do
+      #         requires :name, type: String
+      #       end
+      #     end
       def requires(*attrs, &block)
         orig_attrs = attrs.clone
 
@@ -55,6 +99,10 @@ module Grape
         end
       end
 
+      # Allow, but don't require, one or more parameters for the current
+      #   endpoint.
+      # @param (see #requires)
+      # @option (see #requires)
       def optional(*attrs, &block)
         orig_attrs = attrs.clone
 
@@ -77,24 +125,35 @@ module Grape
         end
       end
 
+      # Disallow the given parameters to be present in the same request.
+      # @param attrs [*Symbol] parameters to validate
       def mutually_exclusive(*attrs)
         validates(attrs, mutual_exclusion: true)
       end
 
+      # Require exactly one of the given parameters to be present.
+      # @param (see #mutually_exclusive)
       def exactly_one_of(*attrs)
         validates(attrs, exactly_one_of: true)
       end
 
+      # Require at least one of the given parameters to be present.
+      # @param (see #mutually_exclusive)
       def at_least_one_of(*attrs)
         validates(attrs, at_least_one_of: true)
       end
 
+      # Require that either all given params are present, or none are.
+      # @param (see #mutually_exclusive)
       def all_or_none_of(*attrs)
         validates(attrs, all_or_none_of: true)
       end
 
       alias_method :group, :requires
 
+      # @param params [Hash] initial hash of parameters
+      # @return hash of parameters relevant for the current scope
+      # @api private
       def params(params)
         params = @parent.params(params) if @parent
         if @element

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -135,6 +135,18 @@ module Grape
           end
         end
 
+        # Declare a "namespace", which prefixes all subordinate routes with its
+        # name. Any endpoints within a namespace, or group, resource, segment,
+        # etc., will share their parent context as well as any configuration
+        # done in the namespace context.
+        #
+        # @example
+        #
+        #     namespace :foo do
+        #       get 'bar' do
+        #         # defines the endpoint: GET /foo/bar
+        #       end
+        #     end
         def namespace(space = nil, options = {}, &block)
           if space || block_given?
             within_namespace do
@@ -162,6 +174,7 @@ module Grape
           @routes ||= prepare_routes
         end
 
+        # Remove all defined routes.
         def reset_routes!
           @routes = nil
         end
@@ -177,6 +190,7 @@ module Grape
           namespace(":#{param}", options, &block)
         end
 
+        # @return array of defined versions
         def versions
           @versions ||= []
         end

--- a/lib/grape/dsl/settings.rb
+++ b/lib/grape/dsl/settings.rb
@@ -2,24 +2,37 @@ require 'active_support/concern'
 
 module Grape
   module DSL
+    # Keeps track of settings (impemented as key-value pairs, grouped by
+    # types), in two contexts: top-level settings which apply globally no
+    # matter where they're defined, and inheritable settings which apply only
+    # in the current scope and scopes nested under it.
     module Settings
       extend ActiveSupport::Concern
 
       attr_accessor :inheritable_setting, :top_level_setting
 
+      # Fetch our top-level settings, which apply to all endpoints in the API.
       def top_level_setting
         @top_level_setting ||= Grape::Util::InheritableSetting.new
       end
 
+      # Fetch our current inheritable settings, which are inherited by
+      # nested scopes but not shared across siblings.
       def inheritable_setting
         @inheritable_setting ||= Grape::Util::InheritableSetting.new.tap { |new_settings| new_settings.inherit_from top_level_setting }
       end
 
+      # @param type [Symbol]
+      # @param key [Symbol]
       def unset(type, key)
         setting = inheritable_setting.send(type)
         setting.delete key
       end
 
+      # @param type [Symbol]
+      # @param key [Symbol]
+      # @param value [Object] will be stored if the value is currently empty
+      # @return either the old value, if it wasn't nil, or the given value
       def get_or_set(type, key, value)
         setting = inheritable_setting.send(type)
         if value.nil?
@@ -29,72 +42,95 @@ module Grape
         end
       end
 
+      # @param key [Symbol]
+      # @param value [Object]
+      # @return (see #get_or_set)
       def global_setting(key, value = nil)
         get_or_set :global, key, value
       end
 
+      # @param key [Symbol]
       def unset_global_setting(key)
         unset :global, key
       end
 
+      # (see #global_setting)
       def route_setting(key, value = nil)
         get_or_set :route, key, value
       end
 
+      # (see #unset_global_setting)
       def unset_route_setting(key)
         unset :route, key
       end
 
+      # (see #global_setting)
       def namespace_setting(key, value = nil)
         get_or_set :namespace, key, value
       end
 
+      # (see #unset_global_setting)
       def unset_namespace_setting(key)
         unset :namespace_setting, key
       end
 
+      # (see #global_setting)
       def namespace_inheritable(key, value = nil)
         get_or_set :namespace_inheritable, key, value
       end
 
+      # (see #unset_global_setting)
       def unset_namespace_inheritable(key)
         unset :namespace_inheritable, key
       end
 
+      # @param key [Symbol]
       def namespace_inheritable_to_nil(key)
         inheritable_setting.namespace_inheritable[key] = nil
       end
 
+      # (see #global_setting)
       def namespace_stackable(key, value = nil)
         get_or_set :namespace_stackable, key, value
       end
 
+      # (see #unset_global_setting)
       def unset_namespace_stackable(key)
         unset :namespace_stackable, key
       end
 
+      # (see #global_setting)
       def api_class_setting(key, value = nil)
         get_or_set :api_class, key, value
       end
 
+      # (see #unset_global_setting)
       def unset_api_class_setting(key)
         unset :api_class_setting, key
       end
 
+      # Fork our inheritable settings to a new instance, copied from our
+      # parent's, but separate so we won't modify it. Every call to this
+      # method should have an answering call to #namespace_end.
       def namespace_start
         @inheritable_setting = Grape::Util::InheritableSetting.new.tap { |new_settings| new_settings.inherit_from inheritable_setting }
       end
 
+      # Set the inheritable settings pointer back up by one level.
       def namespace_end
         route_end
         @inheritable_setting = inheritable_setting.parent
       end
 
+      # Stop defining settings for the current route and clear them for the
+      # next, within a namespace.
       def route_end
         inheritable_setting.route_end
         reset_validations!
       end
 
+      # Execute the block within a context where our inheritable settings are forked
+      # to a new copy (see #namespace_start).
       def within_namespace(&_block)
         namespace_start
 

--- a/lib/grape/dsl/validations.rb
+++ b/lib/grape/dsl/validations.rb
@@ -8,12 +8,16 @@ module Grape
       include Grape::DSL::Configuration
 
       module ClassMethods
+        # Clears all defined parameters and validations.
         def reset_validations!
           unset_namespace_stackable :declared_params
           unset_namespace_stackable :validations
           unset_namespace_stackable :params
         end
 
+        # Opens a root-level ParamsScope, defining parameter coercions and
+        # validations for the endpoint.
+        # @yield instance context of the new scope
         def params(&block)
           Grape::Validations::ParamsScope.new(api: self, type: Hash, &block)
         end

--- a/lib/grape/namespace.rb
+++ b/lib/grape/namespace.rb
@@ -1,22 +1,33 @@
 module Grape
+  # A container for endpoints or other namespaces, which allows for both
+  # logical grouping of endpoints as well as sharing commonconfiguration.
+  # May also be referred to as group, segment, or resource.
   class Namespace
     attr_reader :space, :options
 
-    # options:
-    #   requirements: a hash
+    # @param space [String] the name of this namespace
+    # @param options [Hash] options hash
+    # @option options :requirements [Hash] param-regex pairs, all of which must
+    #   be met by a request's params for all endpoints in this namespace, or
+    #   validation will fail and return a 422.
     def initialize(space, options = {})
       @space = space.to_s
       @options = options
     end
 
+    # Retrieves the requirements from the options hash, if given.
+    # @return [Hash]
     def requirements
       options[:requirements] || {}
     end
 
+    # (see ::joined_space_path)
     def self.joined_space(settings)
       (settings || []).map(&:space).join('/')
     end
 
+    # Join the namespaces from a list of settings to create a path prefix.
+    # @param settings [Array] list of Grape::Util::InheritableSettings.
     def self.joined_space_path(settings)
       Rack::Mount::Utils.normalize_path(joined_space(settings))
     end

--- a/lib/grape/path.rb
+++ b/lib/grape/path.rb
@@ -1,4 +1,5 @@
 module Grape
+  # Represents a path to an endpoint.
   class Path
     def self.prepare(raw_path, namespace, settings)
       Path.new(raw_path, namespace, settings).path_with_suffix

--- a/lib/grape/route.rb
+++ b/lib/grape/route.rb
@@ -1,10 +1,12 @@
 module Grape
   # A compiled route for inspection.
   class Route
+    # @api private
     def initialize(options = {})
       @options = options || {}
     end
 
+    # @api private
     def method_missing(method_id, *arguments)
       match = /route_([_a-zA-Z]\w*)/.match(method_id.to_s)
       if match
@@ -14,12 +16,15 @@ module Grape
       end
     end
 
+    # Generate a short, human-readable representation of this route.
     def to_s
       "version=#{route_version}, method=#{route_method}, path=#{route_path}"
     end
 
     private
 
+    # This is defined so that certain Ruby methods which attempt to call #to_ary
+    # on objects, e.g. Array#join, will not hit #method_missing.
     def to_ary
       nil
     end

--- a/lib/grape/util/parameter_types.rb
+++ b/lib/grape/util/parameter_types.rb
@@ -29,14 +29,14 @@ module Grape
     ]
 
     # @param type [Class] type to check
-    # @returns [Boolean] whether or not the type is known by Grape as a valid
+    # @return [Boolean] whether or not the type is known by Grape as a valid
     #   type for a single value
     def self.primitive?(type)
       PRIMITIVES.include?(type)
     end
 
     # @param type [Class] type to check
-    # @returns [Boolean] whether or not the type is known by Grape as a valid
+    # @return [Boolean] whether or not the type is known by Grape as a valid
     #   data structure type
     # @note This method does not yet consider 'complex types', which inherit
     #   Virtus.model.
@@ -47,7 +47,7 @@ module Grape
     # A valid custom type must implement a class-level `parse` method, taking
     #   one String argument and returning the parsed value in its correct type.
     # @param type [Class] type to check
-    # @returns [Boolean] whether or not the type can be used as a custom type
+    # @return [Boolean] whether or not the type can be used as a custom type
     def self.custom_type?(type)
       !primitive?(type) &&
         !structure?(type) &&

--- a/lib/grape/validations.rb
+++ b/lib/grape/validations.rb
@@ -1,4 +1,5 @@
 module Grape
+  # Registry to store and locate known Validators.
   module Validations
     class << self
       attr_accessor :validators
@@ -6,6 +7,10 @@ module Grape
 
     self.validators = {}
 
+    # Register a new validator, so it can be used to validate parameters.
+    # @param short_name [String] all lower-case, no spaces
+    # @param klass [Class] the validator class. Should inherit from
+    #   Validations::Base.
     def self.register_validator(short_name, klass)
       validators[short_name] = klass
     end

--- a/lib/grape/version.rb
+++ b/lib/grape/version.rb
@@ -1,3 +1,4 @@
 module Grape
+  # The current version of Grape.
   VERSION = '0.12.1'
 end


### PR DESCRIPTION
It's pretty mundane, but this PR increases docs coverage from ~37% to ~50% and fixes the YARD warnings currently in `master`. There's a lot more to do, but this is a start. I did my best to make the documentation moderately useful (as opposed to just restating the method name), but I'd appreciate review of my longer comments in case I've misrepresented anything!

Before:
```
$ yard
[warn]: @param tag has unknown parameter name: name
    in file `lib/grape/api.rb' near line 39
[warn]: Unknown tag @returns in file `lib/grape/util/parameter_types.rb` near line 34
[warn]: Unknown tag @returns in file `lib/grape/util/parameter_types.rb` near line 43
[warn]: Unknown tag @returns in file `lib/grape/util/parameter_types.rb` near line 51
Files:          88
Modules:        54 (   52 undocumented)
Classes:        64 (   54 undocumented)
Constants:      29 (   24 undocumented)
Methods:       370 (  193 undocumented)
 37.52% documented
```

After:
```
$ yard
Files:          88
Modules:        54 (   48 undocumented)
Classes:        64 (   51 undocumented)
Constants:      29 (   22 undocumented)
Methods:       370 (  135 undocumented)
 50.48% documented
```