### PR TITLE
Do not convert Rack::Response to Rack::Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Next Release
 
 * [#1038](https://github.com/intridea/grape/pull/1038): Avoid dup-ing the String class when used in inherited params - [@rnubel](https://github.com/rnubel).
 * [#1042](https://github.com/intridea/grape/issues/1042): Fix coercion of complex arrays - [@dim](https://github.com/dim).
+* [#1045](https://github.com/intridea/grape/pull/1045): Do not convert `Rack::Response` to `Rack::Response` in middleware - [@dmitry](https://github.com/dmitry).
 
 0.12.0 (6/18/2015)
 ==================

--- a/lib/grape/middleware/base.rb
+++ b/lib/grape/middleware/base.rb
@@ -37,6 +37,7 @@ module Grape
       end
 
       def response
+        return @app_response if @app_response.is_a?(Rack::Response)
         Rack::Response.new(@app_response[2], @app_response[0], @app_response[1])
       end
 

--- a/spec/grape/middleware/base_spec.rb
+++ b/spec/grape/middleware/base_spec.rb
@@ -36,21 +36,43 @@ describe Grape::Middleware::Base do
 
   describe '#response' do
     subject { Grape::Middleware::Base.new(response) }
-    let(:response) { ->(_) { [204, { abc: 1 }, 'test'] } }
 
-    it 'status' do
-      subject.call({})
-      expect(subject.response.status).to eq(204)
+    context Array do
+      let(:response) { ->(_) { [204, { abc: 1 }, 'test'] } }
+
+      it 'status' do
+        subject.call({})
+        expect(subject.response.status).to eq(204)
+      end
+
+      it 'body' do
+        subject.call({})
+        expect(subject.response.body).to eq(['test'])
+      end
+
+      it 'header' do
+        subject.call({})
+        expect(subject.response.header).to have_key(:abc)
+      end
     end
 
-    it 'body' do
-      subject.call({})
-      expect(subject.response.body).to eq(['test'])
-    end
+    context Rack::Response do
+      let(:response) { ->(_) { Rack::Response.new('test', 204, abc: 1) } }
 
-    it 'header' do
-      subject.call({})
-      expect(subject.response.header).to have_key(:abc)
+      it 'status' do
+        subject.call({})
+        expect(subject.response.status).to eq(204)
+      end
+
+      it 'body' do
+        subject.call({})
+        expect(subject.response.body).to eq(['test'])
+      end
+
+      it 'header' do
+        subject.call({})
+        expect(subject.response.header).to have_key(:abc)
+      end
     end
   end
 


### PR DESCRIPTION
While using https://github.com/aserafin/grape_logging grape middleware after an upgrading grape from 0.11 to 0.12 I've been stuck with an issue (https://github.com/aserafin/grape_logging/issues/6):

```
NoMethodError (undefined method `downcase' for 2:Fixnum)
```

That's because `Middleware#response` tries to convert `Rack::Response` to `Rack::Response` and fails.