### PR TITLE
Validate params only if another param is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Next Release
 #### Features
 
 * [#1039](https://github.com/intridea/grape/pull/1039): Added support for custom parameter types - [@rnubel](https://github.com/rnubel).
+* [#1047](https://github.com/intridea/grape/pull/1047): Adds `given` to DSL::Parameters, allowing for dependent params - [@rnubel](https://github.com/rnubel).
 * Your contribution here!
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - [Parameter Validation and Coercion](#parameter-validation-and-coercion)
   - [Supported Parameter Types](#supported-parameter-types)
   - [Custom Types](#custom-types)
+  - [Dependent Parameters](#dependent-parameters)
   - [Built-in Validators](#built-in-validators)
   - [Namespace Validation and Coercion](#namespace-validation-and-coercion)
   - [Custom Validators](#custom-validators)
@@ -799,6 +800,21 @@ params do
   requires :name, type: Hash do
     requires :first_name
     requires :last_name
+  end
+end
+```
+
+#### Dependent Parameters
+
+Suppose some of your parameters are only relevant if another parameter is given;
+Grape allows you to express this relationship through the `given` method in your
+parameters block, like so:
+
+```ruby
+params do
+  optional :shelf_id, type: Integer
+  given :shelf_id do
+    requires :bin_id, type: Integer
   end
 end
 ```

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -66,6 +66,7 @@ module Grape
     autoload :InvalidVersionerOption
     autoload :UnknownValidator
     autoload :UnknownOptions
+    autoload :UnknownParameter
     autoload :InvalidWithOptionForRepresent
     autoload :IncompatibleOptionValues
     autoload :MissingGroupTypeError,          'grape/exceptions/missing_group_type'

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -149,6 +149,27 @@ module Grape
         validates(attrs, all_or_none_of: true)
       end
 
+      # Define a block of validations which should be applied if and only if
+      # the given parameter is present. The parameters are not nested.
+      # @param attr [Symbol] the parameter which, if present, triggers the
+      #   validations
+      # @throws Grape::Exceptions::UnknownParameter if `attr` has not been
+      #   defined in this scope yet
+      # @yield a parameter definition DSL
+      def given(attr, &block)
+        fail Grape::Exceptions::UnknownParameter.new(attr) unless declared_param?(attr)
+        new_lateral_scope(dependent_on: attr, &block)
+      end
+
+      # Test for whether a certain parameter has been defined in this params
+      # block yet.
+      # @returns [Boolean] whether the parameter has been defined
+      def declared_param?(param)
+        # @declared_params also includes hashes of options and such, but those
+        # won't be flattened out.
+        @declared_params.flatten.include?(param)
+      end
+
       alias_method :group, :requires
 
       # @param params [Hash] initial hash of parameters

--- a/lib/grape/exceptions/unknown_parameter.rb
+++ b/lib/grape/exceptions/unknown_parameter.rb
@@ -1,0 +1,10 @@
+# encoding: utf-8
+module Grape
+  module Exceptions
+    class UnknownParameter < Base
+      def initialize(param)
+        super(message: compose_message('unknown_parameter', param: param))
+      end
+    end
+  end
+end

--- a/lib/grape/locale/en.yml
+++ b/lib/grape/locale/en.yml
@@ -28,6 +28,7 @@ en:
           resolution: 'available strategy for :using is :path, :header, :param'
         unknown_validator: 'unknown validator: %{validator_type}'
         unknown_options: 'unknown options: %{options}'
+        unknown_parameter: 'unknown parameter: %{param}'
         incompatible_option_values: '%{option1}: %{value1} is incompatible with %{option2}: %{value2}'
         mutual_exclusion: 'are mutually exclusive'
         at_least_one: 'are missing, at least one parameter must be provided'

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -271,4 +271,59 @@ describe Grape::Validations::ParamsScope do
       end.to raise_error Grape::Exceptions::UnsupportedGroupTypeError
     end
   end
+
+  context 'when validations are dependent on a parameter' do
+    before do
+      subject.params do
+        optional :a
+        given :a do
+          requires :b
+        end
+      end
+      subject.get('/test') { declared(params).to_json }
+    end
+
+    it 'applies the validations only if the parameter is present' do
+      get '/test'
+      expect(last_response.status).to eq(200)
+
+      get '/test', a: true
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('b is missing')
+
+      get '/test', a: true, b: true
+      expect(last_response.status).to eq(200)
+    end
+
+    it 'raises an error if the dependent parameter was never specified' do
+      expect do
+        subject.params do
+          given :c do
+          end
+        end
+      end.to raise_error(Grape::Exceptions::UnknownParameter)
+    end
+
+    it 'includes the parameter within #declared(params)' do
+      get '/test', a: true, b: true
+
+      expect(JSON.parse(last_response.body)).to eq('a' => 'true', 'b' => 'true')
+    end
+
+    it 'returns a sensible error message within a nested context' do
+      subject.params do
+        requires :bar, type: Hash do
+          optional :a
+          given :a do
+            requires :b
+          end
+        end
+      end
+      subject.get('/nested') { 'worked' }
+
+      get '/nested', bar: { a: true }
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('bar[b] is missing')
+    end
+  end
 end


### PR DESCRIPTION
Implements #958 (sort of). This allows for the use case where you have some parameters to an endpoint which are only relevant or meaningful if some other parameters are given. It can be used like so:

```ruby
params do
  optional :shelf_id, type: Integer
  given :shelf_id do
    requires :bin_id, type: Integer
  end
end
```

Nested use cases work, too:
```ruby
params do
  requires :product_info, type: Hash do
    requires :name, type: String
    optional :shelf_id, type: Integer
    given :shelf_id do
      requires :bin_id, type: Integer
    end
  end
```

One concern: This type of relationship won't show up properly in grape-swagger, or anything which looks at `Route#route_params` to inspect parameter definitions; even though the elements in the `given` block are actually optional unless `shelf_id` is given, `Route#route_params` will indicate that `bin_id` is required. I could probably get that to instead show up as optional, but I don't know if that's ideal.