### PR TITLE
Remove deprecated rubyforge_project attribute from gemspec

### DIFF
--- a/grape.gemspec
+++ b/grape.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.description = 'A Ruby framework for rapid API development with great conventions.'
   s.license     = 'MIT'
 
-  s.rubyforge_project = 'grape'
-
   s.add_runtime_dependency 'rack', '>= 1.3.0'
   s.add_runtime_dependency 'rack-mount'
   s.add_runtime_dependency 'rack-accept'


### PR DESCRIPTION
Rubyforge.org [closed](https://twitter.com/evanphx/status/399552820380053505) on May 15, 2014, and rubyforge_project attribute [became deprecated](http://rubygems.rubyforge.org/rubygems-update/Gem/Specification.html#attribute-i-rubyforge_project). Remove it from gemspec, then.