### PR TITLE
Fix description rewriting

### DIFF
--- a/lib/grape/dsl/configuration.rb
+++ b/lib/grape/dsl/configuration.rb
@@ -72,6 +72,21 @@ module Grape
           namespace_setting :description, options
           route_setting :description, options
         end
+
+        def description_field(field, value=nil)
+          if value
+            description = route_setting(:description) || route_setting(:description, {})
+            description[field] = value
+          else
+            description = route_setting(:description)
+            description[field] if description
+          end
+        end
+
+        def unset_description_field(field)
+          description = route_setting(:description)
+          description.delete(field) if description
+        end
       end
 
       module_function

--- a/lib/grape/dsl/validations.rb
+++ b/lib/grape/dsl/validations.rb
@@ -13,9 +13,7 @@ module Grape
           unset_namespace_stackable :declared_params
           unset_namespace_stackable :validations
           unset_namespace_stackable :params
-          if route_setting(:description)
-            route_setting(:description)[:params] = nil
-          end
+          unset_description_field :params
         end
 
         # Opens a root-level ParamsScope, defining parameter coercions and
@@ -26,11 +24,7 @@ module Grape
         end
 
         def document_attribute(names, opts)
-          route_setting(:description, {}) unless route_setting(:description)
-
-          route_setting(:description)[:params] ||= {}
-
-          setting = route_setting(:description)[:params]
+          setting = description_field(:params) || description_field(:params, {})
           Array(names).each do |name|
             setting[name[:full_name].to_s] ||= {}
             setting[name[:full_name].to_s].merge!(opts)

--- a/lib/grape/dsl/validations.rb
+++ b/lib/grape/dsl/validations.rb
@@ -13,6 +13,9 @@ module Grape
           unset_namespace_stackable :declared_params
           unset_namespace_stackable :validations
           unset_namespace_stackable :params
+          if route_setting(:description)
+            route_setting(:description)[:params] = nil
+          end
         end
 
         # Opens a root-level ParamsScope, defining parameter coercions and

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -2123,6 +2123,38 @@ describe Grape::API do
         { description: 'Reverses a string.', params: { 's' => { desc: 'string to reverse', type: 'string' } } }
       ]
     end
+    it 'does not inherit param descriptions in consequent namespaces' do
+      subject.desc 'global description'
+      subject.params do
+        requires :param1
+        optional :param2
+      end
+      subject.namespace 'ns1' do
+        get do; end
+      end
+      subject.params do
+        optional :param2
+      end
+      subject.namespace 'ns2' do
+        get do; end
+      end
+      routes_doc = subject.routes.map { |route|
+        { description: route.route_description, params: route.route_params }
+      }
+      expect(routes_doc).to eq [
+        { description: 'global description',
+          params: {
+            'param1' => { required: true },
+            'param2' => { required: false }
+          }
+        },
+        { description: 'global description',
+          params: {
+            'param2' => { required: false }
+          }
+        }
+      ]
+    end
     it 'merges the parameters of the namespace with the parameters of the method' do
       subject.desc 'namespace'
       subject.params do

--- a/spec/grape/dsl/validations_spec.rb
+++ b/spec/grape/dsl/validations_spec.rb
@@ -15,7 +15,13 @@ module Grape
         before do
           subject.namespace_stackable :declared_params, ['dummy']
           subject.namespace_stackable :validations, ['dummy']
+          subject.namespace_stackable :params, ['dummy']
+          subject.route_setting :description, { description: 'lol', params: ['dummy'] }
           subject.reset_validations!
+        end
+
+        after do
+          subject.unset_route_setting :description
         end
 
         it 'resets declared params' do
@@ -24,6 +30,18 @@ module Grape
 
         it 'resets validations' do
           expect(subject.namespace_stackable(:validations)).to eq []
+        end
+
+        it 'resets params' do
+          expect(subject.namespace_stackable(:params)).to eq []
+        end
+
+        it 'resets documentation params' do
+          expect(subject.route_setting(:description)[:params]).to eq nil
+        end
+
+        it 'does not reset documentation description' do
+          expect(subject.route_setting(:description)[:description]).to eq 'lol'
         end
       end
 

--- a/spec/grape/dsl/validations_spec.rb
+++ b/spec/grape/dsl/validations_spec.rb
@@ -16,7 +16,7 @@ module Grape
           subject.namespace_stackable :declared_params, ['dummy']
           subject.namespace_stackable :validations, ['dummy']
           subject.namespace_stackable :params, ['dummy']
-          subject.route_setting :description, { description: 'lol', params: ['dummy'] }
+          subject.route_setting :description, description: 'lol', params: ['dummy']
           subject.reset_validations!
         end
 

--- a/spec/grape/dsl/validations_spec.rb
+++ b/spec/grape/dsl/validations_spec.rb
@@ -37,7 +37,7 @@ module Grape
         end
 
         it 'resets documentation params' do
-          expect(subject.route_setting(:description)[:params]).to eq nil
+          expect(subject.route_setting(:description)[:params]).to be_nil
         end
 
         it 'does not reset documentation description' do


### PR DESCRIPTION
Validations DSL writes something to `route_setting(:description)[:params]` but doesn't clean it in `reset_validations!`.

See new spec `spec/grape/api_spec.rb` — this is similar to our case in a real application where we got grape-swagger generating wrong documentation.

```ruby
desc 'global description'
  params do
    requires :param1
    optional :param2
  end
  namespace 'ns1' do
    get do; end
  end
  params do
    optional :param2
  end
  namespace 'ns2' do
    get do; end
  end
end
```

grape-swagger shows that `/ns2/` requires `param1` but in fact it's callable without it.