### PR TITLE
Add a link to grape-route-helpers gem in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 - [Headers](#headers)
 - [Routes](#routes)
 - [Helpers](#helpers)
+- [Path Helpers](#path-helpers)
 - [Parameter Documentation](#parameter-documentation)
 - [Cookies](#cookies)
 - [HTTP Status Code](#http-status-code)
@@ -1264,6 +1265,10 @@ class API < Grape::API
   end
 end
 ```
+
+## Path Helpers
+
+If you need methods for generating paths inside your endpoints, please see the [grape-route-helpers](https://github.com/reprah/grape-route-helpers) gem.
 
 ## Parameter Documentation
 


### PR DESCRIPTION
This PR adds a line to the README that lets people know about the grape-route-helpers gem. I'll add it to the wiki like @dblock suggested, too.