### PR TITLE
Remove case insensitive Accept header support

### DIFF
--- a/lib/grape/http/headers.rb
+++ b/lib/grape/http/headers.rb
@@ -20,7 +20,6 @@ module Grape
       HTTP_TRANSFER_ENCODING = 'HTTP_TRANSFER_ENCODING'.freeze
       HTTP_ACCEPT            = 'HTTP_ACCEPT'.freeze
 
-      ACCEPT                 = 'accept'.freeze
       FORMAT                 = 'format'.freeze
     end
   end

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -11,13 +11,6 @@ module Grape
         }
       end
 
-      def headers
-        env.dup.inject({}) do |h, (k, v)|
-          h[k.to_s.downcase[5..-1]] = v if k.to_s.downcase.start_with?('http_')
-          h
-        end
-      end
-
       def before
         negotiate_content_type
         read_body_input
@@ -133,7 +126,7 @@ module Grape
       end
 
       def mime_array
-        accept = headers[Grape::Http::Headers::ACCEPT]
+        accept = env[Grape::Http::Headers::HTTP_ACCEPT]
         return [] unless accept
 
         accept_into_mime_and_quality = %r{

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -110,11 +110,6 @@ describe Grape::Middleware::Formatter do
       expect(subject.env['api.format']).to eq(:xml)
     end
 
-    it 'looks for case-indifferent headers' do
-      subject.call('PATH_INFO' => '/info', 'http_accept' => 'application/xml')
-      expect(subject.env['api.format']).to eq(:xml)
-    end
-
     it 'uses quality rankings to determine formats' do
       subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/json; q=0.3,application/xml; q=1.0')
       expect(subject.env['api.format']).to eq(:xml)


### PR DESCRIPTION
Hello!

What was the purpose of finding a `HtTp_AccEPT` case-insensitive way? It also requires traversing all the giant `env` hash :sob:  I cannot find any good reason for doing this and think it's a sort of obsolete stuff.
https://tools.ietf.org/html/rfc3875 says that all the `HTTP_` things are uppercased.

Even if there's a good reason for doing this we should anyway decide what to do with the fact that Grape accesses `Accept` header from another middleware [`Grape::Middleware::Versioner::Header`](https://github.com/intridea/grape/blob/e0b73571388780d46f20cd1fa6bdbb70e5a9b74f/lib/grape/middleware/versioner/header.rb#L87) using uppercased `'HTTP_ACCEPT'`.