### PR TITLE
Make Grape::Exceptions::ValidationErrors#full_messages public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Next Release
 
 * [#1039](https://github.com/intridea/grape/pull/1039): Added support for custom parameter types - [@rnubel](https://github.com/rnubel).
 * [#1047](https://github.com/intridea/grape/pull/1047): Adds `given` to DSL::Parameters, allowing for dependent params - [@rnubel](https://github.com/rnubel).
+* [#1064](https://github.com/intridea/grape/pull/1064): Add public `Grape::Exception::ValidationErrors#full_messages` - [@romanlehnert](https://github.com/romanlehnert).
 * Your contribution here!
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -1102,6 +1102,16 @@ subject.rescue_from Grape::Exceptions::ValidationErrors do |e|
 end
 ```
 
+`Grape::Exceptions::ValidationErrors#full_messages` returns the validation messages as an array. `Grape::Exceptions::ValidationErrors#message` joins the messages to one string.
+
+For responding with an array of validation messages, you can use `Grape::Exceptions::ValidationErrors#full_messages`.
+```ruby
+format :json
+subject.rescue_from Grape::Exceptions::ValidationErrors do |e|
+  error!({ messages: e.full_messages }, 400)
+end
+```
+
 ### I18n
 
 Grape supports I18n for parameter-related error messages, but will fallback to English if

--- a/lib/grape/exceptions/validation_errors.rb
+++ b/lib/grape/exceptions/validation_errors.rb
@@ -37,11 +37,11 @@ module Grape
         as_json.to_json
       end
 
-      private
-
       def full_messages
         map { |attributes, error| full_message(attributes, error) }.uniq
       end
+
+      private
 
       def full_message(attributes, error)
         I18n.t(

--- a/spec/grape/exceptions/validation_errors_spec.rb
+++ b/spec/grape/exceptions/validation_errors_spec.rb
@@ -17,6 +17,18 @@ describe Grape::Exceptions::ValidationErrors do
     end
   end
 
+  describe '#full_messages' do
+    context 'with errors' do
+      let(:validation_error_1) { Grape::Exceptions::Validation.new(params: ['id'], message_key: 'presence') }
+      let(:validation_error_2) { Grape::Exceptions::Validation.new(params: ['name'], message_key: 'presence') }
+      subject { described_class.new(errors: [validation_error_1, validation_error_2]).full_messages }
+
+      it 'returns an array with each errors full message' do
+        expect(subject).to contain_exactly('id is missing', 'name is missing')
+      end
+    end
+  end
+
   context 'api' do
     subject { Class.new(Grape::API) }
 


### PR DESCRIPTION
Belongs to https://github.com/intridea/grape/issues/1058. 

A `Grape::Exceptions::ValidationErrors` responds now public to #full_messages and returns an array of of the validation messages.