### PR TITLE
No longer resetting validations twice

### DIFF
--- a/lib/grape/dsl/settings.rb
+++ b/lib/grape/dsl/settings.rb
@@ -126,7 +126,6 @@ module Grape
       # next, within a namespace.
       def route_end
         inheritable_setting.route_end
-        reset_validations!
       end
 
       # Execute the block within a context where our inheritable settings are forked


### PR DESCRIPTION
In /lib/grape/dsl/settings.rb there was a call to `reset_validations!` that seemed necessary. All the tests are passing. 