### PR TITLE
Add `stream` method to InsideRoute to leverage Rack::Chunked

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -35,7 +35,7 @@ Metrics/MethodLength:
 # Offense count: 8
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 243
+  Max: 271
 
 # Offense count: 17
 Metrics/PerceivedComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Next Release
 * [#1039](https://github.com/intridea/grape/pull/1039): Added support for custom parameter types - [@rnubel](https://github.com/rnubel).
 * [#1047](https://github.com/intridea/grape/pull/1047): Adds `given` to DSL::Parameters, allowing for dependent params - [@rnubel](https://github.com/rnubel).
 * [#1064](https://github.com/intridea/grape/pull/1064): Add public `Grape::Exception::ValidationErrors#full_messages` - [@romanlehnert](https://github.com/romanlehnert).
+* [#1079](https://github.com/intridea/grape/pull/1079): Added `stream` method to take advantage of `Rack::Chunked` [@zbelzer](https://github.com/zbelzer).
 * Your contribution here!
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -2105,6 +2105,8 @@ end
 Use `body false` to return `204 No Content` without any data or content-type.
 
 You can also set the response to a file-like object with `file`.
+Note: Rack will read your entire Enumerable before returning a response. If
+you would like to stream the response, see `stream`.
 
 ```ruby
 class FileStreamer
@@ -2122,6 +2124,16 @@ end
 class API < Grape::API
   get '/' do
     file FileStreamer.new('file.bin')
+  end
+end
+```
+
+If you want a file-like object to be streamed using Rack::Chunked, use `stream`.
+
+```ruby
+class API < Grape::API
+  get '/' do
+    stream FileStreamer.new('file.bin')
   end
 end
 ```

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -122,6 +122,7 @@ module Grape
     autoload :StackableValues
     autoload :InheritableSetting
     autoload :StrictHashConfiguration
+    autoload :FileResponse
   end
 
   module DSL

--- a/lib/grape/util/file_response.rb
+++ b/lib/grape/util/file_response.rb
@@ -1,0 +1,21 @@
+module Grape
+  module Util
+    # A simple class used to identify responses which represent files and do not
+    # need to be formatted or pre-read by Rack::Response
+    class FileResponse
+      attr_reader :file
+
+      # @param file [Object]
+      def initialize(file)
+        @file = file
+      end
+
+      # Equality provided mostly for tests.
+      #
+      # @return [Boolean]
+      def ==(other)
+        file == other.file
+      end
+    end
+  end
+end

--- a/spec/grape/dsl/inside_route_spec.rb
+++ b/spec/grape/dsl/inside_route_spec.rb
@@ -201,8 +201,43 @@ module Grape
             subject.file 'file'
           end
 
-          it 'returns value' do
-            expect(subject.file).to eq 'file'
+          it 'returns value wrapped in FileResponse' do
+            expect(subject.file).to eq Grape::Util::FileResponse.new('file')
+          end
+        end
+
+        it 'returns default' do
+          expect(subject.file).to be nil
+        end
+      end
+
+      describe '#stream' do
+        describe 'set' do
+          before do
+            subject.header 'Cache-Control', 'cache'
+            subject.header 'Content-Length', 123
+            subject.header 'Transfer-Encoding', 'base64'
+            subject.stream 'file'
+          end
+
+          it 'returns value wrapped in FileResponse' do
+            expect(subject.stream).to eq Grape::Util::FileResponse.new('file')
+          end
+
+          it 'also sets result of file to value wrapped in FileResponse' do
+            expect(subject.file).to eq Grape::Util::FileResponse.new('file')
+          end
+
+          it 'sets Cache-Control header to no-cache' do
+            expect(subject.header['Cache-Control']).to eq 'no-cache'
+          end
+
+          it 'sets Content-Length header to nil' do
+            expect(subject.header['Content-Length']).to eq nil
+          end
+
+          it 'sets Transfer-Encoding header to nil' do
+            expect(subject.header['Transfer-Encoding']).to eq nil
           end
         end
 


### PR DESCRIPTION
Also necessary was the introduction of an object (`FileResponse`) so the formatting middleware would leave files and other enumerables alone. Seemed better than relying on methods on the object as enumerables have `each` defined. I've been writing scala recently so I think I have case classes on the brain.